### PR TITLE
fix(frontend): render all generated run artifacts

### DIFF
--- a/asset/task_workspace_runtime_knowledge_pack.md
+++ b/asset/task_workspace_runtime_knowledge_pack.md
@@ -48,7 +48,7 @@ Use it when changing task APIs, task state transitions, runner behavior, event l
 - User message cards expose a copy action whose clipboard text is exactly `message.content`. Assistant copy support remains on the final-answer card; execution-log copy/export uses the full safe run log set, including rows hidden by compact default rendering.
 - Reasoning summaries render inside the same run-grouped progress card as operation logs, with a distinct `思考摘要` label. The frontend does not create a separate reasoning/history card.
 - Backend task errors, needs-input notices, missing provider-key warnings, local upload warnings, copy failures, and artifact-open failures should stay in the conversation stream as robot-authored assistant notices, not detached banners.
-- Report artifacts render as independent result/download cards and must open/download through token-aware blob fetching. Prefer run-scoped artifact URLs when a `run_id` is available.
+- Generated run artifacts render as independent result/download cards, including non-report Markdown/JSON outputs as well as HTML reports. They must open/download through token-aware blob fetching. Prefer run-scoped artifact URLs when a `run_id` is available.
 - The frontend may map known fixed English backend legacy strings to Chinese through an explicit whitelist. Do not add broad automatic translation for user text, filenames, URLs, uploaded content, or model replies.
 - Provider keys such as `DEEPSEEK_API_KEY` and `TAVILY_API_KEY` are backend-only. Browser-visible `NEXT_PUBLIC_*` values must not contain provider keys, customer text, or private credentials.
 - Missing `DEEPSEEK_API_KEY` for simple chat is a provider-configuration warning, not a hard frontend error. Document-analysis fallback behavior should remain available.
@@ -138,6 +138,7 @@ Output: backend MYAGENT_CORS_ORIGINS includes http://<LAN_IP>:3001, backend acce
 - Top-level artifact URLs resolve to the latest completed run containing that artifact name, then fall back to legacy top-level files.
 - Frontend message submission sends `mode` only for normal first-party runs. The composer intentionally does not expose Auto/Do not use files/Use files choices; file relevance is decided by backend routing and, for DeepAgent runs, by the model's audited file-tool calls.
 - Frontend run activity grouping suppresses setup-only `task_created` and `file_uploaded` fallback history when real run cards exist, while preserving unmatched warning/error logs.
+- Frontend run activity grouping must include every backend-provided run artifact name or artifact record; filtering to report-like or HTML-only names hides valid generated files.
 - Frontend normalizes `deep_agent_activity` into `ExecutionLog.agentActivity` only when `schema_version`, enum fields, and required safe text fields are valid. Malformed activity payloads fall back to normal log rendering and must not expose arbitrary payload JSON in DOM or copied logs.
 - Frontend normalizes `reasoning_trace` into `ExecutionLog.reasoning` only when the payload is valid. Malformed reasoning payloads fall back to normal log rendering and must not expose arbitrary payload JSON in DOM or copied logs.
 - Frontend run cards show at most three info-level reasoning summaries by default; warning/error logs always remain visible. The expand/collapse control discloses the hidden reasoning count, and copied logs include all reasoning summaries.
@@ -175,8 +176,8 @@ Output: backend MYAGENT_CORS_ORIGINS includes http://<LAN_IP>:3001, backend acce
 - Do not render backend task errors, needs-input notices, or frontend workspace warnings as full-width detached banners.
 - Do not turn the workspace into a marketing landing page when applying the warm editorial visual system; keep the first screen usable as the task composer and history workspace.
 - Do not reintroduce the old cool-blue/slate visual theme for primary actions, selected states, or run chrome unless the frontend visual-token contract is intentionally replaced.
-- Do not flatten multi-run logs and reports into one undifferentiated report area.
-- Do not place report artifact actions only inside a log card footer.
+- Do not flatten multi-run logs and artifacts into one undifferentiated result area.
+- Do not place artifact actions only inside a log card footer.
 - Do not let the sticky composer obscure the newest assistant output after logs or artifacts are inserted.
 - Do not pass `AuditedWorkspaceTools` instances, task directories, or absolute paths directly into DeepAgent code; pass only the callables returned by the adapter.
 - Do not pass raw DeepAgent output filenames directly into artifact storage; promote them through the artifact-safe naming boundary so ordinary model-created names with spaces or punctuation cannot fail an otherwise successful run.

--- a/frontend/app/workspace-view.ts
+++ b/frontend/app/workspace-view.ts
@@ -22,7 +22,7 @@ export type RunActivityGroup = {
   startedAt?: string;
   completedAt?: string;
   logs: ExecutionLog[];
-  reportArtifacts: Artifact[];
+  artifacts: Artifact[];
 };
 
 export type VisibleLogPartition = {
@@ -416,11 +416,6 @@ export function formatRunLogStatus(status: TaskStatus) {
   }
 }
 
-export function isReportArtifact(artifact: Artifact) {
-  const marker = `${artifact.name} ${artifact.kind ?? ""} ${artifact.path ?? ""} ${artifact.url ?? ""}`.toLowerCase();
-  return marker.includes("report") || marker.includes(".html");
-}
-
 function runTimeValue(run: TaskRunRecord) {
   return run.startedAt ?? run.completedAt ?? "";
 }
@@ -491,7 +486,6 @@ export function buildRunActivityGroups(
     );
     const artifactMap = new Map<string, Artifact>();
     [...run.artifactNames.map((name) => artifactFromRunName(run.id, name)), ...runArtifacts]
-      .filter(isReportArtifact)
       .forEach((artifact) => {
         const key = artifactKeyForRun(run.id, artifact);
         if (!artifactMap.has(key)) {
@@ -508,7 +502,7 @@ export function buildRunActivityGroups(
       logs: logs
         .filter((log) => log.runId === run.id || (runs.length === 1 && !log.runId))
         .sort(byCreatedAt),
-      reportArtifacts: Array.from(artifactMap.values()),
+      artifacts: Array.from(artifactMap.values()),
     };
   });
 
@@ -520,23 +514,20 @@ export function buildRunActivityGroups(
     (artifact) =>
       (!artifact.runId && runs.length !== 1) || (artifact.runId && !knownRunIds.has(artifact.runId)),
   );
-  const fallbackReportArtifacts = fallbackArtifacts.filter(isReportArtifact);
   const visibleFallbackLogs =
     runs.length > 0 ? fallbackLogs.filter((log) => !isSetupFallbackLog(log)) : fallbackLogs;
 
-  if (visibleFallbackLogs.length > 0 || fallbackReportArtifacts.length > 0) {
+  if (visibleFallbackLogs.length > 0 || fallbackArtifacts.length > 0) {
     groups.push({
       runId: "legacy",
       title: runs.length > 0 ? "历史日志" : "第 1 轮",
       status: "unknown",
       logs: visibleFallbackLogs.sort(byCreatedAt),
-      reportArtifacts: fallbackReportArtifacts.map((artifact) =>
-        artifactForRenderedRun("legacy", artifact),
-      ),
+      artifacts: fallbackArtifacts.map((artifact) => artifactForRenderedRun("legacy", artifact)),
     });
   }
 
-  return groups.filter((group) => group.logs.length > 0 || group.reportArtifacts.length > 0);
+  return groups.filter((group) => group.logs.length > 0 || group.artifacts.length > 0);
 }
 
 function groupTimeValue(group: RunActivityGroup) {
@@ -572,7 +563,7 @@ export function buildConversationStreamItems(
   }
 
   function pushArtifactItems(group: RunActivityGroup) {
-    group.reportArtifacts.forEach((artifact) => {
+    group.artifacts.forEach((artifact) => {
       items.push({
         id: `artifact:${group.runId}:${artifact.name}`,
         kind: "artifact",

--- a/frontend/tests/workspace/test_workspace_view.test.ts
+++ b/frontend/tests/workspace/test_workspace_view.test.ts
@@ -251,7 +251,7 @@ test("formatTaskStatus keeps run badges localized", () => {
   assert.equal(formatTaskStatus("unknown"), "历史");
 });
 
-test("buildRunActivityGroups groups logs and reports by run chronologically", () => {
+test("buildRunActivityGroups groups logs and artifacts by run chronologically", () => {
   const groups = buildRunActivityGroups(
     [
       {
@@ -295,7 +295,7 @@ test("buildRunActivityGroups groups logs and reports by run chronologically", ()
 
   assert.deepEqual(groups.map((group) => group.runId), ["run-1", "run-2"]);
   assert.deepEqual(groups[0].logs.map((log) => log.id), ["event-1a", "event-1b"]);
-  assert.equal(groups[0].reportArtifacts[0].runId, "run-1");
+  assert.equal(groups[0].artifacts[0].runId, "run-1");
 });
 
 test("buildRunActivityGroups keeps reasoning traces chronologically with operation logs", () => {
@@ -515,26 +515,51 @@ test("buildRunActivityGroups keeps non-upload orphan logs as neutral history", (
   assert.deepEqual(groups.at(-1)?.logs.map((log) => log.id), ["orphan-warning"]);
 });
 
-test("buildRunActivityGroups dedupes unscoped report artifacts by rendered run", () => {
+test("buildRunActivityGroups keeps fallback non-report artifacts visible", () => {
   const groups = buildRunActivityGroups(
     [
       {
         id: "run-1",
         status: "complete",
         startedAt: "2026-04-27T08:00:00.000Z",
-        artifactNames: ["report.html"],
+        artifactNames: [],
       },
     ],
     [],
-    [{ id: "legacy-report", name: "report.html" }],
+    [{ id: "missing-run:final-summary.md", name: "final-summary.md", runId: "missing-run" }],
+  );
+
+  assert.deepEqual(groups.map((group) => group.runId), ["legacy"]);
+  assert.deepEqual(groups[0].artifacts.map((artifact) => artifact.name), ["final-summary.md"]);
+  assert.equal(groups[0].artifacts[0].runId, "legacy");
+});
+
+test("buildRunActivityGroups dedupes unscoped artifacts by rendered run", () => {
+  const groups = buildRunActivityGroups(
+    [
+      {
+        id: "run-1",
+        status: "complete",
+        startedAt: "2026-04-27T08:00:00.000Z",
+        artifactNames: ["final-summary.md", "report.html"],
+      },
+    ],
+    [],
+    [
+      { id: "legacy-summary", name: "final-summary.md" },
+      { id: "legacy-report", name: "report.html" },
+    ],
   );
 
   assert.deepEqual(groups.map((group) => group.runId), ["run-1"]);
-  assert.equal(groups[0].reportArtifacts.length, 1);
-  assert.equal(groups[0].reportArtifacts[0].runId, "run-1");
+  assert.deepEqual(groups[0].artifacts.map((artifact) => artifact.name), [
+    "final-summary.md",
+    "report.html",
+  ]);
+  assert.equal(groups[0].artifacts[0].runId, "run-1");
 });
 
-test("buildRunActivityGroups keeps same report names separate across runs", () => {
+test("buildRunActivityGroups keeps same artifact names separate across runs", () => {
   const groups = buildRunActivityGroups(
     [
       {
@@ -558,9 +583,9 @@ test("buildRunActivityGroups keeps same report names separate across runs", () =
   );
 
   assert.deepEqual(groups.map((group) => group.runId), ["run-1", "run-2"]);
-  assert.deepEqual(groups.map((group) => group.reportArtifacts.length), [1, 1]);
-  assert.equal(groups[0].reportArtifacts[0].runId, "run-1");
-  assert.equal(groups[1].reportArtifacts[0].runId, "run-2");
+  assert.deepEqual(groups.map((group) => group.artifacts.length), [1, 1]);
+  assert.equal(groups[0].artifacts[0].runId, "run-1");
+  assert.equal(groups[1].artifacts[0].runId, "run-2");
 });
 
 test("isWarningChatMessage recognizes explicit and legacy provider warnings", () => {
@@ -618,14 +643,14 @@ test("buildConversationStreamItems places run activity before the assistant repl
       title: "第 1 轮",
       status: "complete" as const,
       logs: [{ id: "event-1", title: "第一轮", runId: "run-1" }],
-      reportArtifacts: [],
+      artifacts: [],
     },
     {
       runId: "run-2",
       title: "第 2 轮",
       status: "running" as const,
       logs: [{ id: "event-2", title: "第二轮", runId: "run-2" }],
-      reportArtifacts: [],
+      artifacts: [],
     },
   ];
 
@@ -656,14 +681,23 @@ test("buildConversationStreamItems places artifact cards after assistant replies
         title: "第 1 轮",
         status: "complete" as const,
         logs: [{ id: "event-1", title: "完成", runId: "run-1" }],
-        reportArtifacts: [{ id: "run-1:report.html", name: "report.html", runId: "run-1" }],
+        artifacts: [
+          { id: "run-1:final-summary.md", name: "final-summary.md", runId: "run-1" },
+          { id: "run-1:evidence.json", name: "evidence.json", runId: "run-1" },
+        ],
       },
     ],
   );
 
   assert.deepEqual(
     items.map((item) => item.id),
-    ["message:m1", "run:run-1", "message:m2", "artifact:run-1:report.html"],
+    [
+      "message:m1",
+      "run:run-1",
+      "message:m2",
+      "artifact:run-1:final-summary.md",
+      "artifact:run-1:evidence.json",
+    ],
   );
 });
 
@@ -676,7 +710,7 @@ test("buildConversationStreamItems keeps artifact cards after run logs without a
         title: "第 1 轮",
         status: "running" as const,
         logs: [{ id: "event-1", title: "写入报告", runId: "run-1" }],
-        reportArtifacts: [{ id: "run-1:report.html", name: "report.html", runId: "run-1" }],
+        artifacts: [{ id: "run-1:report.html", name: "report.html", runId: "run-1" }],
       },
     ],
   );


### PR DESCRIPTION
## Changes

- Render every run artifact returned by task state instead of filtering to report/html-like names.
- Rename the internal run activity grouping field to `artifacts` so the frontend contract matches the backend artifact list.
- Cover run-scoped non-report artifacts, fallback artifacts, and artifact stream placement in workspace tests.
- Document the durable artifact visibility boundary in the runtime knowledge pack.

## Affected files

- frontend/app/workspace-view.ts
- frontend/tests/workspace/test_workspace_view.test.ts
- asset/task_workspace_runtime_knowledge_pack.md

## Testing

- [x] cd frontend && node --test --import tsx tests/workspace/test_workspace_view.test.ts
- [x] cd frontend && npm test
- [x] cd frontend && npm run typecheck
- [x] cd frontend && npm run lint
- [x] cd frontend && npm run build
- [x] git diff --check

Closes #2
