### PR TITLE
修复(contract): 增加 SessionEvent 契约与兼容事件序号

### DIFF
--- a/asset/task_workspace_runtime_knowledge_pack.md
+++ b/asset/task_workspace_runtime_knowledge_pack.md
@@ -18,6 +18,7 @@ Use it when changing task APIs, task state transitions, runner behavior, event l
 - Uploads support `.md` and `.json` files through `POST /api/tasks/{task_id}/files`. Backend filename checks and JSON parsing are authoritative; MIME type alone is not trusted.
 - Upload validation is atomic. Invalid file type, invalid JSON, duplicate names, file-count limits, file-size limits, request-size limits, or overlong filenames must reject the batch without partial persistence.
 - Every new run has a non-empty `run_id`. New user messages, assistant messages, events, run records, and run-scoped artifacts should carry that `run_id`.
+- Session events are the append-only Harness truth boundary. New events should be representable as `SessionEvent` contracts with `session_id`, stable increasing `seq`, `type`, `message`, `created_at`, safe `payload`, optional `run_id`, optional `level`, and optional `idempotency_key`; legacy `EventRecord`/`after_id` APIs remain compatibility surfaces until the frontend projection is migrated.
 - Successful terminal transitions must not expose a `complete` task state before the corresponding success event (`chat_completed`, `search_completed`, `deep_agent_completed`, or `task_completed`) is persisted for the same `run_id`.
 - Search/weather runs must synthesize a final answer after tool use. Search result formatting may be used only as a bounded source-summary helper or fallback, not as the normal successful assistant answer.
 - Search synthesis uses the `TaskRunner`'s injected model provider. It should not instantiate a separate provider router inside the runner unless ownership is intentionally refactored.
@@ -199,6 +200,7 @@ Output: backend MYAGENT_CORS_ORIGINS includes http://<LAN_IP>:3001, backend acce
 - Runtime JSON parse failures after a previously valid upload indicate local storage drift or corruption and should fail the run with a filename-specific error.
 - JSON upload and runtime parse failures should keep filenames visible but must not expose raw parser text such as Python or Pydantic English messages.
 - `TaskStorage.get_task()` may derive `events`, `artifacts`, `upload_count`, and `run_count`, but derived fields are not persisted back as authoritative data.
+- `TaskStorage` is temporarily allowed to bridge old task storage and the new `SessionStore` contract. It must write `seq` and `session_id` for new JSONL events, and must synthesize compatible values when reading legacy events that do not have those fields.
 - Top-level artifact URLs resolve to the latest completed run containing that artifact name, then fall back to legacy top-level files.
 - Frontend message submission sends `mode` only for normal first-party runs. The composer intentionally does not expose Auto/Do not use files/Use files choices; file relevance is decided by backend routing and, for DeepAgent runs, by the model's audited file-tool calls.
 - Frontend run activity grouping suppresses setup-only `task_created` and `file_uploaded` fallback history when real run cards exist, while preserving unmatched warning/error logs.

--- a/backend/app/contracts/__init__.py
+++ b/backend/app/contracts/__init__.py
@@ -1,0 +1,12 @@
+"""Stable Harness contracts shared by runtime adapters."""
+
+from .events import EventLevel, NewSessionEvent, SessionEvent, SessionSnapshot
+from .session import SessionStore
+
+__all__ = [
+    "EventLevel",
+    "NewSessionEvent",
+    "SessionEvent",
+    "SessionSnapshot",
+    "SessionStore",
+]

--- a/backend/app/contracts/events.py
+++ b/backend/app/contracts/events.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+EventLevel = Literal["info", "success", "warning", "error"]
+
+
+@dataclass(frozen=True)
+class SessionEvent:
+    id: str
+    session_id: str
+    seq: int
+    type: str
+    created_at: datetime
+    message: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    run_id: str | None = None
+    level: EventLevel | None = None
+    idempotency_key: str | None = None
+
+
+@dataclass(frozen=True)
+class NewSessionEvent:
+    type: str
+    message: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    run_id: str | None = None
+    level: EventLevel | None = None
+    idempotency_key: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionSnapshot:
+    session_id: str
+    created_at: datetime
+    latest_seq: int
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/backend/app/contracts/session.py
+++ b/backend/app/contracts/session.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .events import NewSessionEvent, SessionEvent, SessionSnapshot
+
+
+@runtime_checkable
+class SessionStore(Protocol):
+    def create_session(self, metadata: dict[str, Any]) -> SessionSnapshot:
+        ...
+
+    def get_session(self, session_id: str) -> SessionSnapshot:
+        ...
+
+    def get_events(
+        self,
+        session_id: str,
+        *,
+        after_seq: int | None = None,
+        limit: int | None = None,
+        reverse: bool = False,
+    ) -> list[SessionEvent]:
+        ...
+
+    def emit_event(self, session_id: str, event: NewSessionEvent) -> SessionEvent:
+        ...

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -35,12 +35,15 @@ class ChatMessage(BaseModel):
 
 class EventRecord(BaseModel):
     id: str
+    session_id: str | None = None
+    seq: int | None = None
     type: str
     message: str
     created_at: str
     payload: dict[str, Any] = Field(default_factory=dict)
     run_id: str | None = None
     level: Literal["info", "success", "warning", "error"] | None = None
+    idempotency_key: str | None = None
 
 
 class ArtifactRecord(BaseModel):

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, TypeAlias
 
 from fastapi import UploadFile
 
+from .contracts import EventLevel, NewSessionEvent, SessionEvent, SessionSnapshot
 from .reasoning_trace import (
     ReasoningConfidence,
     ReasoningPhase,
@@ -33,7 +34,7 @@ EventAppendSpec: TypeAlias = tuple[
     str,
     str,
     dict[str, Any],
-    Literal["info", "success", "warning", "error"] | None,
+    EventLevel | None,
 ]
 UPLOAD_CHUNK_SIZE = 1024 * 1024
 MAX_FILENAME_BYTES = 180
@@ -86,6 +87,10 @@ class UploadLimitError(ValueError):
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_utc_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def safe_filename(name: str) -> str:
@@ -171,6 +176,25 @@ def summary_title(messages: list[ChatMessage]) -> str:
         if visible:
             return visible[:5]
     return "新对话"
+
+
+def session_event_from_record(record: EventRecord) -> SessionEvent:
+    if record.session_id is None:
+        raise ValueError("事件缺少 session_id")
+    if record.seq is None:
+        raise ValueError("事件缺少 seq")
+    return SessionEvent(
+        id=record.id,
+        session_id=record.session_id,
+        seq=record.seq,
+        type=record.type,
+        created_at=parse_utc_timestamp(record.created_at),
+        message=record.message,
+        payload=record.payload,
+        run_id=record.run_id,
+        level=record.level,
+        idempotency_key=record.idempotency_key,
+    )
 
 
 class TaskStorage:
@@ -526,7 +550,7 @@ class TaskStorage:
         payload: dict[str, Any] | None = None,
         *,
         run_id: str | None = None,
-        level: Literal["info", "success", "warning", "error"] | None = None,
+        level: EventLevel | None = None,
     ) -> EventRecord:
         with self._lock:
             return self._append_event_unlocked(
@@ -538,6 +562,50 @@ class TaskStorage:
                 level=level,
             )
 
+    def emit_event(self, session_id: str, event: NewSessionEvent) -> SessionEvent:
+        with self._lock:
+            record = self._append_event_unlocked(
+                session_id,
+                event.type,
+                event.message,
+                event.payload,
+                run_id=event.run_id,
+                level=event.level,
+                idempotency_key=event.idempotency_key,
+            )
+            return session_event_from_record(record)
+
+    def get_session(self, session_id: str) -> SessionSnapshot:
+        state = self.get_task(session_id, include_events=False)
+        return SessionSnapshot(
+            session_id=state.task_id,
+            created_at=parse_utc_timestamp(state.created_at),
+            latest_seq=self._latest_event_seq(session_id),
+            metadata={"model": state.model, "status": state.status},
+        )
+
+    def get_events(
+        self,
+        session_id: str,
+        *,
+        after_seq: int | None = None,
+        limit: int | None = None,
+        reverse: bool = False,
+    ) -> list[SessionEvent]:
+        events = [session_event_from_record(event) for event in self.read_events(session_id)]
+        if after_seq is not None:
+            events = [event for event in events if event.seq > after_seq]
+        if reverse:
+            events = list(reversed(events))
+        if limit is not None:
+            events = events[: max(0, limit)]
+        return events
+
+    def create_session(self, metadata: dict[str, Any]) -> SessionSnapshot:
+        model = str(metadata.get("model") or "deepseek-reasoner")
+        state = self.create_task(None, model)
+        return self.get_session(state.task_id)
+
     def _append_event_unlocked(
         self,
         task_id: str,
@@ -546,18 +614,23 @@ class TaskStorage:
         payload: dict[str, Any],
         *,
         run_id: str | None = None,
-        level: Literal["info", "success", "warning", "error"] | None = None,
+        level: EventLevel | None = None,
+        idempotency_key: str | None = None,
     ) -> EventRecord:
         if run_id:
             validate_run_id(run_id)
+        seq = self._next_event_seq(task_id)
         event = EventRecord(
             id=uuid.uuid4().hex,
+            session_id=task_id,
+            seq=seq,
             type=event_type,
             message=message,
             created_at=utc_now(),
             payload=payload,
             run_id=run_id,
             level=level,
+            idempotency_key=idempotency_key,
         )
         events_path = self.task_dir(task_id) / "logs" / "events.jsonl"
         with events_path.open("a", encoding="utf-8") as handle:
@@ -573,7 +646,7 @@ class TaskStorage:
         if missing:
             raise ValueError(f"文件工具审计记录缺少字段：{', '.join(sorted(missing))}")
         status = payload.get("status")
-        level: Literal["info", "success", "warning", "error"] = "info"
+        level: EventLevel = "info"
         if status in {"denied", "cancelled"}:
             level = "warning"
         elif status == "failed":
@@ -627,7 +700,7 @@ class TaskStorage:
                 if not line.strip():
                     continue
                 try:
-                    event = EventRecord(**json.loads(line))
+                    event = self._event_record_from_json(task_id, json.loads(line), index + 1)
                 except JSONDecodeError:
                     if index == len(lines) - 1:
                         break
@@ -637,6 +710,39 @@ class TaskStorage:
                 elif event.id == after_id:
                     include = True
             return events
+
+    def _event_record_from_json(
+        self, task_id: str, raw_event: Mapping[str, Any], fallback_seq: int
+    ) -> EventRecord:
+        data = dict(raw_event)
+        data.setdefault("session_id", task_id)
+        data.setdefault("seq", fallback_seq)
+        return EventRecord(**data)
+
+    def _next_event_seq(self, task_id: str) -> int:
+        return self._latest_event_seq(task_id) + 1
+
+    def _latest_event_seq(self, task_id: str) -> int:
+        events_path = self.task_dir(task_id) / "logs" / "events.jsonl"
+        if not events_path.exists():
+            return 0
+        latest_seq = 0
+        lines = events_path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if not line.strip():
+                continue
+            try:
+                raw_event = json.loads(line)
+            except JSONDecodeError:
+                if index == len(lines) - 1:
+                    break
+                raise
+            raw_seq = raw_event.get("seq")
+            if isinstance(raw_seq, int) and raw_seq > 0:
+                latest_seq = max(latest_seq, raw_seq)
+            else:
+                latest_seq = max(latest_seq, index + 1)
+        return latest_seq
 
     def list_task_ids(self) -> list[str]:
         with self._lock:

--- a/backend/tests/runtime/test_session_contracts.py
+++ b/backend/tests/runtime/test_session_contracts.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from app.contracts import NewSessionEvent, SessionEvent, SessionSnapshot, SessionStore
+from app.storage import TaskStorage
+
+
+def test_task_storage_emits_session_events_with_sequence_and_session_id(tmp_path) -> None:
+    storage = TaskStorage(tmp_path / "sessions")
+    snapshot = storage.create_session({"model": "deepseek-reasoner"})
+
+    emitted = storage.emit_event(
+        snapshot.session_id,
+        NewSessionEvent(
+            type="contract.test",
+            message="契约测试事件。",
+            payload={"ok": True},
+            level="info",
+            idempotency_key="contract-test-1",
+        ),
+    )
+    events = storage.get_events(snapshot.session_id)
+
+    assert isinstance(storage, SessionStore)
+    assert isinstance(snapshot, SessionSnapshot)
+    assert isinstance(emitted, SessionEvent)
+    assert [event.seq for event in events] == [1, 2]
+    assert {event.session_id for event in events} == {snapshot.session_id}
+    assert events[-1].type == "contract.test"
+    assert events[-1].payload == {"ok": True}
+    assert events[-1].idempotency_key == "contract-test-1"
+    assert isinstance(events[-1].created_at, datetime)
+
+
+def test_task_storage_get_events_filters_after_seq_and_supports_limit(tmp_path) -> None:
+    storage = TaskStorage(tmp_path / "sessions")
+    snapshot = storage.create_session({"model": "deepseek-reasoner"})
+    second = storage.emit_event(
+        snapshot.session_id,
+        NewSessionEvent(type="second", message="Second", payload={}),
+    )
+    storage.emit_event(
+        snapshot.session_id,
+        NewSessionEvent(type="third", message="Third", payload={}),
+    )
+
+    assert [event.type for event in storage.get_events(snapshot.session_id, after_seq=second.seq)] == [
+        "third"
+    ]
+    assert [event.type for event in storage.get_events(snapshot.session_id, limit=2)] == [
+        "task_created",
+        "second",
+    ]
+    assert [event.type for event in storage.get_events(snapshot.session_id, reverse=True, limit=1)] == [
+        "third"
+    ]
+    assert storage.get_session(snapshot.session_id).latest_seq == 3
+
+
+def test_legacy_jsonl_events_are_read_with_compatible_sequence(tmp_path) -> None:
+    storage = TaskStorage(tmp_path / "sessions")
+    state = storage.create_task(None, "deepseek-reasoner")
+    events_path = tmp_path / "sessions" / state.task_id / "logs" / "events.jsonl"
+    legacy_event = {
+        "id": "legacy-event",
+        "type": "legacy",
+        "message": "Legacy event",
+        "created_at": "2026-04-30T00:00:00Z",
+        "payload": {"legacy": True},
+        "run_id": None,
+        "level": None,
+    }
+    events_path.write_text(json.dumps(legacy_event, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    read_events = storage.read_events(state.task_id)
+    session_events = storage.get_events(state.task_id)
+
+    assert read_events[0].session_id == state.task_id
+    assert read_events[0].seq == 1
+    assert session_events[0].session_id == state.task_id
+    assert session_events[0].seq == 1
+    assert session_events[0].type == "legacy"

--- a/backend/tests/workflow/test_workflow.py
+++ b/backend/tests/workflow/test_workflow.py
@@ -2292,6 +2292,8 @@ def test_task_events_endpoint_supports_incremental_reads(tmp_path: Path) -> None
 
     assert summary["events"] == []
     assert [event["type"] for event in incremental] == ["second"]
+    assert incremental[0]["session_id"] == task_id
+    assert incremental[0]["seq"] == 2
 
 
 def test_read_events_ignores_partial_jsonl_tail(tmp_path: Path) -> None:


### PR DESCRIPTION
# 修复(contract): 增加 SessionEvent 契约与兼容事件序号

Closes #9

## 对应规范

- `MyAgent_Harness_重构指导文档.md` 第 4.1 节：`SessionStore` 是 Harness 的任务真相。
- 第 5 节：事件类型规范与事件字段要求。
- 第 6 节 Phase 1：先定义 contracts，并让 `TaskStorage` 临时实现最小 `SessionStore` 接口。
- 第 10 节 PR 1：新增 contracts，不改 `TaskRunner` 主流程。

## 本次改动

- 新增 `backend/app/contracts/`，定义 `SessionEvent`、`NewSessionEvent`、`SessionSnapshot` 与 `SessionStore`。
- 兼容扩展 `EventRecord`，加入 `session_id`、`seq` 和 `idempotency_key` 字段。
- 让 `TaskStorage` 新写入事件带稳定递增 `seq` 与 `session_id`，并为旧 JSONL 事件读取时补齐兼容字段。
- 增加 `create_session()`、`get_session()`、`get_events()`、`emit_event()` 桥接方法，保留旧 `append_event()` / `read_events()` 行为。
- 更新长期知识包，记录 Session event 作为 Harness append-only truth boundary。

## 验收标准

- [x] 新增 Harness 事件契约类型，不依赖具体 runner 实现。
- [x] 新写入事件包含稳定递增 `seq` 与 `session_id`。
- [x] 旧 JSONL 事件读取时能补齐兼容 `seq`，不破坏历史任务读取。
- [x] 现有 `/api/tasks/{task_id}/events?after_id=...` 行为保持兼容。
- [x] 后端测试覆盖契约转换、序号递增和旧事件兼容。
- [x] 更新长期知识包，记录事件契约和兼容边界。
- [x] 目标验证和必要检查通过。
- [x] 未混入 `TaskRunner` 主流程迁移、前端交互变化、数据库/队列/部署变化。

## 验证

```bash
cd backend && uv run pytest tests/runtime/test_session_contracts.py tests/workflow/test_workflow.py::test_task_events_endpoint_supports_incremental_reads tests/workflow/test_workflow.py::test_read_events_ignores_partial_jsonl_tail -q
cd backend && uv run ruff check .
cd backend && uv run mypy app tests
cd backend && uv run pytest
git diff --check
```

后端全量测试结果：149 passed。
