### PR TITLE
修复(runtime): model_provider asyncio.run() 在已有事件循环线程中崩溃

### DIFF
--- a/backend/app/model_provider.py
+++ b/backend/app/model_provider.py
@@ -122,7 +122,28 @@ class DeepSeekProvider:
     ) -> str:
         if controller.is_cancelled():
             raise RuntimeError("模型调用已取消")
-        return asyncio.run(self._chat_http_cancellable_async(message, model, controller))
+        coro = self._chat_http_cancellable_async(message, model, controller)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+        else:
+            # Already in an event loop; run the coroutine in a new thread
+            # with a fresh event loop to avoid nested-loop errors.
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(self._run_coro_in_new_loop, coro)
+                return future.result()
+
+    @staticmethod
+    def _run_coro_in_new_loop(coro: Any) -> Any:
+        new_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(new_loop)
+        try:
+            return new_loop.run_until_complete(coro)
+        finally:
+            new_loop.close()
 
     async def _chat_http_cancellable_async(
         self, message: str, model: str, controller: CancellationController

--- a/backend/tests/runtime/test_model_provider_event_loop.py
+++ b/backend/tests/runtime/test_model_provider_event_loop.py
@@ -1,0 +1,67 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.model_provider import DeepSeekProvider
+from app.runtime import CancellationController
+from app.settings import Settings
+
+
+def _test_settings() -> Settings:
+    return Settings(
+        task_root=Path("/tmp/test-tasks"),
+        deepseek_api_key="test-key",
+        deepseek_base_url="https://api.test.com",
+        tavily_api_key=None,
+        workspace_root=Path("/tmp/test-workspace"),
+        deepseek_timeout_seconds=5,
+    )
+
+
+class TestChatHttpCancellableEventLoop:
+    """Regression tests for Issue #25: asyncio.run() crash in running event loop."""
+
+    def test_chat_http_cancellable_no_running_loop(self) -> None:
+        """When no event loop is running, _chat_http_cancellable should work normally."""
+        provider = DeepSeekProvider(_test_settings())
+        controller = CancellationController()
+
+        with patch.object(
+            provider, "_chat_http_cancellable_async", return_value="hello"
+        ) as mock_async:
+            result = provider._chat_http_cancellable("msg", "model", controller)
+
+        assert result == "hello"
+        mock_async.assert_called_once_with("msg", "model", controller)
+
+    def test_chat_http_cancellable_with_running_loop(self) -> None:
+        """When an event loop is already running, _chat_http_cancellable should not crash."""
+        provider = DeepSeekProvider(_test_settings())
+        controller = CancellationController()
+
+        async def inner() -> str:
+            with patch.object(
+                provider, "_chat_http_cancellable_async", return_value="hello"
+            ) as mock_async:
+                result = provider._chat_http_cancellable("msg", "model", controller)
+                mock_async.assert_called_once_with("msg", "model", controller)
+            return result
+
+        # Simulate being called from a thread that already has an event loop
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(inner())
+            assert result == "hello"
+        finally:
+            loop.close()
+
+    def test_chat_http_cancellable_already_cancelled(self) -> None:
+        """If controller is already cancelled, should raise RuntimeError immediately."""
+        provider = DeepSeekProvider(_test_settings())
+        controller = CancellationController()
+        controller.cancel()
+
+        with pytest.raises(RuntimeError, match="模型调用已取消"):
+            provider._chat_http_cancellable("msg", "model", controller)


### PR DESCRIPTION
## 变更内容

修复 `backend/app/model_provider.py` 中的 `_chat_http_cancellable` 方法在已有事件循环的线程中调用 `asyncio.run()` 导致崩溃的问题。

**问题根因**: 
- `_chat_http_cancellable` 使用 `asyncio.run()` 在同步上下文中执行异步 HTTP 请求
- 当该方法从已有事件循环的线程（如 FastAPI 主线程或测试环境）被调用时，`asyncio.run()` 会抛出 `RuntimeError("asyncio.run() cannot be called from a running event loop")`
- 这会导致模型调用直接崩溃，任务被标记为失败

**修复策略**:
1. 检测当前是否已有运行中的事件循环（`asyncio.get_running_loop()`）
2. 如果没有事件循环，安全使用 `asyncio.run()`（原有行为）
3. 如果已有事件循环，在新线程中创建新的事件循环运行异步代码，避免嵌套事件循环错误

## 受影响文件

- `backend/app/model_provider.py`
- `backend/tests/runtime/test_model_provider_event_loop.py`（新增回归测试）

## 验证

- [x] `uv run pytest tests/runtime/test_model_provider_event_loop.py` 通过（3/3）
- [x] `uv run pytest tests/` 全部通过（108/108）
- [x] `uv run ruff check .` 通过
- [x] `uv run mypy app tests` 通过
- [x] 未引入无关格式化或行为变更

## 风险与回滚

- **风险**: 新线程创建有微小性能开销（仅在已有事件循环时触发）
- **兼容性**: 不影响原有路径（无非事件循环线程）的行为
- **回滚**: 如需回滚，直接 revert 本提交即可

Closes #25
