### PR TITLE
修复(error-handling): run_cancellable_command 管道死锁

### DIFF
--- a/backend/app/runtime.py
+++ b/backend/app/runtime.py
@@ -6,7 +6,7 @@ import subprocess
 import time
 from concurrent.futures import Future
 from subprocess import Popen
-from threading import Event, RLock
+from threading import Event, RLock, Thread
 
 
 class CancellationController:
@@ -80,6 +80,14 @@ def _wait_short(process: Popen, timeout: float) -> None:
         time.sleep(0.05)
 
 
+def _drain_pipe(pipe, accumulator: list[str]) -> None:
+    while True:
+        chunk = pipe.read(4096)
+        if not chunk:
+            break
+        accumulator.append(chunk)
+
+
 def run_cancellable_command(
     command: list[str],
     *,
@@ -97,6 +105,14 @@ def run_cancellable_command(
         start_new_session=os.name != "nt",
     )
     controller.register_process(process)
+
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    stdout_thread = Thread(target=_drain_pipe, args=(process.stdout, stdout_parts))
+    stderr_thread = Thread(target=_drain_pipe, args=(process.stderr, stderr_parts))
+    stdout_thread.start()
+    stderr_thread.start()
+
     try:
         deadline = time.monotonic() + timeout
         while process.poll() is None:
@@ -107,9 +123,12 @@ def run_cancellable_command(
                 controller.cancel()
                 raise TimeoutError(f"命令执行超过 {timeout} 秒限制")
             time.sleep(0.05)
-        stdout, stderr = process.communicate()
+        stdout_thread.join(timeout=2.0)
+        stderr_thread.join(timeout=2.0)
         if controller.is_cancelled():
             raise RuntimeError("命令已取消")
-        return subprocess.CompletedProcess(command, process.returncode or 0, stdout, stderr)
+        return subprocess.CompletedProcess(
+            command, process.returncode or 0, "".join(stdout_parts), "".join(stderr_parts)
+        )
     finally:
         controller.unregister_process(process)

--- a/backend/tests/runtime/test_runtime_pipe_deadlock.py
+++ b/backend/tests/runtime/test_runtime_pipe_deadlock.py
@@ -1,0 +1,56 @@
+import subprocess
+import sys
+from pathlib import Path
+from threading import Thread
+
+import pytest
+
+from app.runtime import CancellationController, run_cancellable_command
+
+
+class TestRunCancellableCommandPipeDeadlock:
+    """Regression tests for Issue #29: subprocess pipe deadlock with large output."""
+
+    def test_large_output_does_not_deadlock(self, tmp_path: Path) -> None:
+        """A command producing 1MB of stdout should complete without hanging."""
+        controller = CancellationController()
+        # Produce ~1MB of output without newlines to stress the pipe buffer.
+        result = run_cancellable_command(
+            [
+                sys.executable,
+                "-c",
+                "print('x' * 1_000_000)",
+            ],
+            cwd=str(tmp_path),
+            timeout=30.0,
+            controller=controller,
+        )
+        assert result.returncode == 0
+        assert len(result.stdout) >= 1_000_000
+
+    def test_cancel_terminates_process(self, tmp_path: Path) -> None:
+        """Cancelling the controller must terminate the subprocess promptly."""
+        controller = CancellationController()
+        outcome: dict[str, str] = {}
+
+        def run_command() -> None:
+            try:
+                run_cancellable_command(
+                    [sys.executable, "-c", "import time; time.sleep(10)"],
+                    cwd=str(tmp_path),
+                    timeout=120,
+                    controller=controller,
+                )
+            except RuntimeError as exc:
+                outcome["error"] = str(exc)
+
+        thread = Thread(target=run_command)
+        thread.start()
+        # Give the command time to start.
+        import time
+        time.sleep(0.2)
+        controller.cancel()
+        thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert "取消" in outcome["error"]


### PR DESCRIPTION
## 变更内容

修复 `backend/app/runtime.py` 中的 `run_cancellable_command` 使用 `subprocess.Popen` 时因 stdout/stderr PIPE 未读取而导致的大输出死锁问题。

**问题根因**:
- 原代码使用 `Popen` 并设置 `stdout=subprocess.PIPE, stderr=subprocess.PIPE`
- 在轮询期间（`while process.poll() is None`）未读取管道内容
- 子进程产生大量输出时，PIPE 缓冲区（64KB）填满，子进程阻塞在 `write()` 上
- 命令挂起直到超时

**修复策略**:
- 保留 `subprocess.Popen`（以支持 `controller.cancel()` 进程终止）
- 启动独立线程持续读取 stdout/stderr，防止管道缓冲区填满
- 主线程继续轮询取消和超时

**与之前尝试的区别**:
- 之前尝试使用 `subprocess.run()` + `ThreadPoolExecutor`，但破坏了进程取消功能
- 当前方案保留 `Popen` + `register_process`，确保取消仍能终止子进程

## 受影响文件

- `backend/app/runtime.py`
- `backend/tests/runtime/test_runtime_pipe_deadlock.py`（新增回归测试）

## 验证

- [x] `uv run pytest tests/runtime/test_runtime_pipe_deadlock.py` 通过（2/2）
- [x] `uv run pytest tests/workflow/test_workflow.py::test_runtime_command_cancel_terminates_process` 通过
- [x] `uv run pytest tests/` 全部通过（108/108）
- [x] 未引入无关格式化或行为变更

## 风险与回滚

- **风险**: 新增两个读取线程，有微小内存和调度开销
- **兼容性**: 保持原有 API 和取消行为不变
- **回滚**: 如需回滚，直接 revert 本提交即可

Closes #29
