### PR TITLE
修复(security): storage 路径校验和 tools 搜索后缀校验加固

### DIFF
--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -222,6 +222,8 @@ class TaskStorage:
         self._lock = threading.RLock()
 
     def task_dir(self, task_id: str) -> Path:
+        if not task_id or task_id in {".", ".."}:
+            raise ValueError("任务 ID 不能为空或相对路径")
         path = (self.task_root / task_id).resolve()
         if self.task_root not in path.parents and path != self.task_root:
             raise ValueError("任务路径超出任务根目录")

--- a/backend/app/tools.py
+++ b/backend/app/tools.py
@@ -508,6 +508,9 @@ def sanitize_file_tool_reason(reason: str, workspace_root: Path) -> str:
     return "文件访问失败"
 
 
+ALLOWED_SEARCH_SUFFIXES = {".md", ".json", ".txt"}
+
+
 class WorkspaceTools:
     def __init__(
         self,
@@ -536,6 +539,8 @@ class WorkspaceTools:
         return path.read_text(encoding="utf-8")
 
     def full_text_search(self, query: str, suffix: str = ".md") -> list[dict[str, Any]]:
+        if suffix not in ALLOWED_SEARCH_SUFFIXES:
+            raise ValueError(f"不支持的搜索后缀：{suffix}")
         self.controller.raise_if_cancelled()
         results: list[dict[str, Any]] = []
         for path in self.workspace_root.rglob(f"*{suffix}"):

--- a/backend/tests/security/test_input_validation.py
+++ b/backend/tests/security/test_input_validation.py
@@ -1,0 +1,76 @@
+"""Tests for input validation hardening in storage and tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.permissions import PermissionPolicy
+from app.storage import TaskStorage
+from app.tools import WorkspaceTools
+
+
+class TestTaskDirValidation:
+    """Verify task_dir rejects empty and relative-path task IDs."""
+
+    def _make_storage(self, tmp_path: Path) -> TaskStorage:
+        return TaskStorage(tmp_path / "tasks")
+
+    def test_empty_string_rejected(self, tmp_path: Path) -> None:
+        storage = self._make_storage(tmp_path)
+        with pytest.raises(ValueError, match="任务 ID 不能为空"):
+            storage.task_dir("")
+
+    def test_dot_rejected(self, tmp_path: Path) -> None:
+        storage = self._make_storage(tmp_path)
+        with pytest.raises(ValueError, match="任务 ID 不能为空或相对路径"):
+            storage.task_dir(".")
+
+    def test_dotdot_rejected(self, tmp_path: Path) -> None:
+        storage = self._make_storage(tmp_path)
+        with pytest.raises(ValueError, match="任务 ID 不能为空或相对路径"):
+            storage.task_dir("..")
+
+    def test_valid_task_id_accepted(self, tmp_path: Path) -> None:
+        storage = self._make_storage(tmp_path)
+        result = storage.task_dir("abc-123")
+        assert result.name == "abc-123"
+
+
+class TestFullTextSearchSuffixValidation:
+    """Verify full_text_search rejects disallowed suffixes."""
+
+    def _make_tools(self, tmp_path: Path) -> WorkspaceTools:
+        policy = PermissionPolicy(workspace_root=tmp_path)
+        return WorkspaceTools(
+            workspace_root=tmp_path,
+            policy=policy,
+            tavily_api_key=None,
+        )
+
+    def test_disallowed_suffix_rejected(self, tmp_path: Path) -> None:
+        tools = self._make_tools(tmp_path)
+        with pytest.raises(ValueError, match="不支持的搜索后缀"):
+            tools.full_text_search("test", suffix=".py")
+
+    def test_disallowed_suffix_exe(self, tmp_path: Path) -> None:
+        tools = self._make_tools(tmp_path)
+        with pytest.raises(ValueError, match="不支持的搜索后缀"):
+            tools.full_text_search("test", suffix=".exe")
+
+    def test_md_suffix_allowed(self, tmp_path: Path) -> None:
+        tools = self._make_tools(tmp_path)
+        # No files, but should not raise
+        results = tools.full_text_search("test", suffix=".md")
+        assert isinstance(results, list)
+
+    def test_json_suffix_allowed(self, tmp_path: Path) -> None:
+        tools = self._make_tools(tmp_path)
+        results = tools.full_text_search("test", suffix=".json")
+        assert isinstance(results, list)
+
+    def test_txt_suffix_allowed(self, tmp_path: Path) -> None:
+        tools = self._make_tools(tmp_path)
+        results = tools.full_text_search("test", suffix=".txt")
+        assert isinstance(results, list)


### PR DESCRIPTION
## 变更内容

修复 `backend/app/storage.py` 中的 `task_dir` 对空字符串防护不足的问题，以及 `backend/app/tools.py` 中的 `full_text_search` 后缀未经验证的问题。

**问题 1**: `task_dir` 对空 task_id 返回 task_root
- 当 `task_id=""` 时，`path = self.task_root`，条件判断失效，返回 `task_root` 本身
- 可能导致任务间数据交叉污染

**修复 1**: 在 `task_dir` 开头增加显式校验，拒绝空字符串、"." 和 ".."

**问题 2**: `full_text_search` 的 suffix 参数未经验证
- 传入空字符串时会遍历工作区所有文件
- 可能导致性能问题和信息泄露

**修复 2**: 增加白名单校验，只允许 `.md`, `.json`, `.txt`

## 受影响文件

- `backend/app/storage.py`
- `backend/app/tools.py`
- `backend/tests/security/test_input_validation.py`（新增回归测试）

## 验证

- [x] `uv run pytest tests/` 全部通过（108/108）
- [x] `uv run ruff check .` 通过
- [x] 新增测试覆盖非法 task_id 和非法 suffix 场景

## 风险与回滚

- **风险**: 无运行时风险，仅增加输入校验
- **兼容性**: 正常 task_id 和 suffix 不受影响
- **回滚**: 如需回滚，直接 revert 本提交即可

Closes #27
