### PR TITLE
修复 #30：前端轮询竞态、会话切换竞态、API URL 编码

### DIFF
--- a/frontend/hooks/use-task-workspace.ts
+++ b/frontend/hooks/use-task-workspace.ts
@@ -69,6 +69,8 @@ export function useTaskWorkspace() {
   const [errorLevel, setErrorLevel] = useState<"warning" | "error">("error");
   const [copiedCopyKey, setCopiedCopyKey] = useState("");
   const copyFeedbackTimerRef = useRef<number | null>(null);
+  const logsRef = useRef<ExecutionLog[]>([]);
+  logsRef.current = logs;
 
   const canSend = input.trim().length > 0 || selectedFiles.length > 0;
   const activeTask = isTaskActive(status);
@@ -191,12 +193,12 @@ export function useTaskWorkspace() {
       if (!id) {
         return;
       }
-      const incoming = await fetchTaskEvents(id, logs.at(-1)?.id);
+      const incoming = await fetchTaskEvents(id, logsRef.current.at(-1)?.id);
       if (incoming.length > 0) {
         setLogs((current) => mergeExecutionLogs(current, incoming));
       }
     },
-    [logs, taskId],
+    [taskId],
   );
 
   useEffect(() => {
@@ -327,12 +329,15 @@ export function useTaskWorkspace() {
       setError("");
       setInput("");
       setSelectedFiles([]);
+      setIsBusy(true);
 
       try {
         await refreshTask(id);
       } catch (caught) {
         setErrorLevel("error");
         setError(formatTaskApiFailure(caught));
+      } finally {
+        setIsBusy(false);
       }
     },
     [isBusy, refreshTask, taskId],

--- a/frontend/lib/task-api.ts
+++ b/frontend/lib/task-api.ts
@@ -86,12 +86,17 @@ export async function createTask(model: string): Promise<{ id: string; state: Ta
 
 export async function fetchTask(id: string, options: { includeEvents?: boolean } = {}) {
   const query = options.includeEvents === false ? "?include_events=false" : "";
-  return normalizeTaskState(await requestTaskJson<unknown>(`/api/tasks/${id}${query}`), id);
+  return normalizeTaskState(
+    await requestTaskJson<unknown>(`/api/tasks/${encodeURIComponent(id)}${query}`),
+    id,
+  );
 }
 
 export async function fetchTaskEvents(id: string, afterId?: string): Promise<ExecutionLog[]> {
   const query = afterId ? `?after_id=${encodeURIComponent(afterId)}` : "";
-  return normalizeEventRecords(await requestTaskJson<unknown>(`/api/tasks/${id}/events${query}`));
+  return normalizeEventRecords(
+    await requestTaskJson<unknown>(`/api/tasks/${encodeURIComponent(id)}/events${query}`),
+  );
 }
 
 export async function uploadTaskFiles(id: string, files: File[]) {
@@ -102,27 +107,29 @@ export async function uploadTaskFiles(id: string, files: File[]) {
   const formData = new FormData();
   files.forEach((file) => formData.append("files", file));
 
-  await requestTaskJson<unknown>(`/api/tasks/${id}/files`, {
+  await requestTaskJson<unknown>(`/api/tasks/${encodeURIComponent(id)}/files`, {
     method: "POST",
     body: formData,
   });
 }
 
 export async function postTaskMessage(id: string, content: string, model: string) {
-  await requestTaskJson<unknown>(`/api/tasks/${id}/messages`, {
+  await requestTaskJson<unknown>(`/api/tasks/${encodeURIComponent(id)}/messages`, {
     method: "POST",
     body: JSON.stringify(buildMessageRequestPayload(content, model)),
   });
 }
 
 export async function cancelTask(id: string) {
-  await requestTaskJson<unknown>(`/api/tasks/${id}/cancel`, { method: "POST" });
+  await requestTaskJson<unknown>(`/api/tasks/${encodeURIComponent(id)}/cancel`, {
+    method: "POST",
+  });
 }
 
 export async function fetchArtifactBlob(artifact: Artifact, taskId: string) {
   const request = buildArtifactRequest(
     artifact,
-    taskId,
+    encodeURIComponent(taskId),
     TASK_API_BASE_URL,
     TASK_API_ACCESS_TOKEN,
   );


### PR DESCRIPTION
## 背景
Issue #30 指出前端核心 hook 存在多个竞态和性能问题。

## 改动
- `task-api.ts`: 为所有任务 ID 路径参数添加 `encodeURIComponent`
- `use-task-workspace.ts`: 使用 `logsRef` 消除 `refreshTaskEvents` 对 `logs` state 的依赖，避免轮询 interval 因日志更新而频繁重置
- `use-task-workspace.ts`: `handleSelectConversation` 增加 `isBusy` 状态保护，防止快速点击导致并发 `refreshTask` 竞态

## 关联
- Closes #30