### PR TITLE
修复 #31：后端 CORS 限制、_invoke_agent 校验、runner 竞态

### DIFF
--- a/backend/app/deep_agent_runtime.py
+++ b/backend/app/deep_agent_runtime.py
@@ -512,12 +512,12 @@ class DeepAgentRuntime:
     def _invoke_agent(self, agent: Any, request: DeepAgentRunRequest) -> Any:
         payload = self._agent_payload(request)
         config = self._agent_config(request)
-        if hasattr(agent, "invoke"):
+        if hasattr(agent, "invoke") and callable(getattr(agent, "invoke")):
             try:
                 return agent.invoke(payload, config=config)
             except TypeError:
                 return agent.invoke(payload)
-        if hasattr(agent, "run"):
+        if hasattr(agent, "run") and callable(getattr(agent, "run")):
             return agent.run(payload)
         if callable(agent):
             try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -83,8 +83,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         CORSMiddleware,
         allow_origins=list(resolved_settings.cors_origins),
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization", "X-MyAgent-Token", "X-Agent-Chat-Token"],
     )
 
     @app.get("/health")

--- a/backend/app/runner.py
+++ b/backend/app/runner.py
@@ -1090,7 +1090,10 @@ def utc_now() -> str:
 def build_input_manifest(uploads: list[Path]) -> list[dict[str, Any]]:
     manifest: list[dict[str, Any]] = []
     for path in uploads:
-        stat = path.stat()
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            continue
         manifest.append(
             {
                 "filename": path.name,


### PR DESCRIPTION
## 背景
Issue #31 指出后端存在多个中等级别的安全和正确性问题。

## 改动
- `main.py`: CORS `allow_methods` 从 `[\"*\"]` 收紧为显式方法列表
- `main.py`: CORS `allow_headers` 从 `[\"*\"]` 收紧为显式头列表
- `deep_agent_runtime.py`: `_invoke_agent` 回退逻辑增加 `callable` 校验
- `runner.py`: `build_input_manifest` 对 `path.stat()` 添加 `FileNotFoundError` 防护

## 关联
- Closes #31