### PR TITLE
修复 #32：storage 状态文件损坏防护和 analysis 取消响应

### DIFF
--- a/backend/app/analysis.py
+++ b/backend/app/analysis.py
@@ -1061,7 +1061,7 @@ def similar_paragraph_pairs(
             comparisons += 1
             if comparisons > MAX_SIMILARITY_COMPARISONS_PER_PAIR:
                 return sorted(pairs, key=lambda item: item["score"], reverse=True)[:4]
-            if comparisons % 500 == 0 and controller is not None and controller.is_cancelled():
+            if comparisons % 100 == 0 and controller is not None and controller.is_cancelled():
                 raise CancelledError()
             score = SequenceMatcher(
                 None, normalize_text(left_text), normalize_text(right_text)

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -982,7 +982,11 @@ class TaskStorage:
             return self._resolve_run_artifact_path(task_id, run, name)
 
     def _read_state(self, task_id: str, *, synthesize_legacy: bool = False) -> TaskState:
-        data = json.loads((self.task_dir(task_id) / "state.json").read_text(encoding="utf-8"))
+        state_path = self.task_dir(task_id) / "state.json"
+        try:
+            data = json.loads(state_path.read_text(encoding="utf-8"))
+        except JSONDecodeError as exc:
+            raise ValueError(f"任务 {task_id} 的状态文件损坏：{exc}") from exc
         data.pop("events", None)
         data.pop("artifacts", None)
         state = TaskState(**data)


### PR DESCRIPTION
## 背景
Issue #32 指出后端存在错误处理和性能问题。

## 改动
- `storage.py`: `_read_state` 捕获 `JSONDecodeError` 并转换为明确 `ValueError`
- `analysis.py`: `similar_paragraph_pairs` 取消检查间隔从 500 次比较缩短为 100 次，提高取消响应灵敏度

## 关联
- Closes #32