### PR TITLE
修复 #33：为核心 hook 和 API 层补充基础测试

### DIFF
--- a/frontend/tests/workspace/test_task_api.test.ts
+++ b/frontend/tests/workspace/test_task_api.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+void describe("task-api exports", () => {
+  void it("should export expected functions", async () => {
+    const api = await import("../../lib/task-api");
+    assert.strictEqual(typeof api.requestTaskJson, "function");
+    assert.strictEqual(typeof api.fetchTask, "function");
+    assert.strictEqual(typeof api.fetchTaskEvents, "function");
+    assert.strictEqual(typeof api.createTask, "function");
+    assert.strictEqual(typeof api.uploadTaskFiles, "function");
+    assert.strictEqual(typeof api.postTaskMessage, "function");
+    assert.strictEqual(typeof api.cancelTask, "function");
+    assert.strictEqual(typeof api.fetchArtifactBlob, "function");
+  });
+});

--- a/frontend/tests/workspace/test_task_workspace.test.ts
+++ b/frontend/tests/workspace/test_task_workspace.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+void describe("use-task-workspace exports", () => {
+  void it("should export useTaskWorkspace hook", async () => {
+    const mod = await import("../../hooks/use-task-workspace");
+    assert.strictEqual(typeof mod.useTaskWorkspace, "function");
+  });
+});


### PR DESCRIPTION
## 背景
Issue #33 指出核心 hook 和 API 层缺乏测试覆盖。

## 改动
- 新增 `test_task_api.test.ts`：验证 task-api 模块关键导出
- 新增 `test_task_workspace.test.ts`：验证 use-task-workspace hook 导出

## 关联
- Closes #33