### PR TITLE
修复 DeepAgents v2 StreamPart dict 格式解析

### DIFF
--- a/backend/app/agent_activity.py
+++ b/backend/app/agent_activity.py
@@ -20,7 +20,7 @@ ActivitySink: TypeAlias = Callable[[dict[str, Any]], Any]
 ACTIVITY_KINDS = {"lifecycle", "progress"}
 ACTIVITY_PHASES = {"planning", "reasoning", "tool_use", "file_operation", "finalizing"}
 ACTIVITY_STATUSES = {"started", "running", "completed", "failed", "skipped"}
-STREAM_MODES = {"updates", "messages"}
+STREAM_MODES = {"updates", "messages", "custom"}
 BOUNDARY_STATUSES = {"started", "completed", "failed", "skipped"}
 SENSITIVE_KEY_PATTERN = re.compile(
     r"(?:api[_-]?key|secret|token|authorization|password|credential|content|prompt|body|result)",
@@ -728,6 +728,12 @@ def activity_payload_from_file_audit(
 
 
 def _split_stream_chunk(chunk: Any) -> tuple[str | None, Any, list[str]]:
+    if isinstance(chunk, Mapping):
+        chunk_type = chunk.get("type")
+        if chunk_type in STREAM_MODES:
+            return chunk_type, chunk.get("data"), _path_items(chunk.get("ns"))
+        if chunk_type is not None:
+            return None, chunk, []
     if isinstance(chunk, tuple):
         if len(chunk) == 3 and isinstance(chunk[1], str) and chunk[1] in STREAM_MODES:
             return chunk[1], chunk[2], _path_items(chunk[0])
@@ -752,8 +758,6 @@ def _infer_mode(data: Any) -> str | None:
         return "messages"
     if _looks_like_message(data):
         return "messages"
-    if isinstance(data, Mapping):
-        return "updates"
     return None
 
 

--- a/backend/tests/runtime/test_agent_activity.py
+++ b/backend/tests/runtime/test_agent_activity.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from app.agent_activity import _split_stream_chunk
+
+
+class TestSplitStreamChunk:
+    """Tests for _split_stream_chunk v2 dict format support."""
+
+    def test_v2_dict_updates(self):
+        chunk = {"type": "updates", "ns": ("tools:abc123",), "data": {"node": "value"}}
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode == "updates"
+        assert data == {"node": "value"}
+        assert path == ["tools:abc123"]
+
+    def test_v2_dict_messages(self):
+        chunk = {"type": "messages", "ns": (), "data": ("token", "meta")}
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode == "messages"
+        assert data == ("token", "meta")
+        assert path == []
+
+    def test_v2_dict_custom(self):
+        chunk = {"type": "custom", "ns": ["tools:x"], "data": {"progress": 50}}
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode == "custom"
+        assert data == {"progress": 50}
+        assert path == ["tools:x"]
+
+    def test_v2_dict_missing_type_returns_fallback(self):
+        chunk = {"ns": ("tools:a",), "data": "value"}
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode is None
+        assert data == chunk
+        assert path == []
+
+    def test_v2_dict_unknown_type_returns_fallback(self):
+        chunk = {"type": "unknown", "ns": (), "data": "value"}
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode is None
+        assert data == chunk
+        assert path == []
+
+    def test_tuple_three_element(self):
+        chunk = (("ns",), "updates", {"node": "value"})
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode == "updates"
+        assert data == {"node": "value"}
+        assert path == ["ns"]
+
+    def test_tuple_two_element_mode_first(self):
+        chunk = ("updates", {"node": "value"})
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode == "updates"
+        assert data == {"node": "value"}
+        assert path == []
+
+    def test_tuple_nested(self):
+        chunk = (("ns",), ("updates", {"node": "value"}))
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode == "updates"
+        assert data == {"node": "value"}
+        assert path == ["ns"]
+
+    def test_plain_dict_without_type_still_fallback(self):
+        chunk = {"data": "something"}
+        mode, data, path = _split_stream_chunk(chunk)
+        assert mode is None
+        assert data == chunk
+        assert path == []


### PR DESCRIPTION
## 修复内容

修复 `_split_stream_chunk()` 无法正确解析 DeepAgents v2 `StreamPart` dict 格式的问题。

### 变更摘要

1. **`_split_stream_chunk()`** 现在优先检查 `Mapping`（dict）格式，提取 `type`、`ns`、`data` 字段。
2. **扩展 `STREAM_MODES`** 为 `{"updates", "messages", "custom"}`，为后续 `custom` 模式支持做准备。
3. **修复 `_infer_mode()`** 移除对未知 `Mapping` 的盲目推断 `"updates"`，避免误解析。
4. **新增单元测试** `backend/tests/runtime/test_agent_activity.py`，9 个用例覆盖：
   - v2 dict `updates` / `messages` / `custom` 格式
   - 未知 type / 缺失 type 的 fallback 行为
   - 旧元组三种格式的向后兼容

### 验证结果

- `uv run pytest`：212 测试全部通过
- `uv run ruff check app/agent_activity.py tests/runtime/test_agent_activity.py`：通过
- 原有元组格式 chunk 解析结果不变

### 风险说明

低风险。仅修改 chunk 解析逻辑，不改变下游事件处理或存储格式。向后兼容旧元组格式。

Closes #45
