### PR TITLE
添加 custom stream_mode 支持

### DIFF
--- a/backend/app/agent_activity.py
+++ b/backend/app/agent_activity.py
@@ -444,6 +444,9 @@ class DeepAgentActivityProjector:
         if mode == "updates":
             self._observe_update_data(data, subgraph_path)
             return
+        if mode == "custom":
+            self._observe_custom_data(data, subgraph_path)
+            return
         self.emit(
             activity_kind="progress",
             phase="reasoning",
@@ -533,6 +536,32 @@ class DeepAgentActivityProjector:
             title="DeepAgent 进度更新",
             summary="DeepAgent 已更新运行状态。",
             subgraph_path=subgraph_path,
+        )
+
+    def _observe_custom_data(self, data: Any, subgraph_path: list[str]) -> None:
+        agent_name = _agent_name_from_path(subgraph_path)
+        title = "自定义进度"
+        summary = "收到自定义进度事件。"
+        if isinstance(data, Mapping):
+            status = str(data.get("status") or "")
+            if status:
+                title = f"自定义进度：{status}"
+            topic = str(data.get("topic") or data.get("message") or "")
+            if topic:
+                summary = topic[:200]
+        elif isinstance(data, str):
+            summary = data[:200]
+        self.emit(
+            activity_kind="progress",
+            phase="tool_use",
+            status="running",
+            title=title,
+            summary=summary,
+            subgraph_path=subgraph_path,
+            live=build_live_status_metadata(
+                agent_name=agent_name,
+                stage="using_tool",
+            ),
         )
 
     def _observe_message_data(self, data: Any, subgraph_path: list[str]) -> None:

--- a/backend/app/deep_agent_runtime.py
+++ b/backend/app/deep_agent_runtime.py
@@ -490,7 +490,7 @@ class DeepAgentRuntime:
                 config=config,
                 subgraphs=True,
                 version="v2",
-                stream_mode=["updates", "messages"],
+                stream_mode=["updates", "messages", "custom"],
             )
         except TypeError:
             return None

--- a/backend/tests/runtime/test_agent_activity.py
+++ b/backend/tests/runtime/test_agent_activity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.agent_activity import _split_stream_chunk
+from app.agent_activity import DeepAgentActivityProjector, _split_stream_chunk
 
 
 class TestSplitStreamChunk:
@@ -68,3 +68,46 @@ class TestSplitStreamChunk:
         assert mode is None
         assert data == chunk
         assert path == []
+
+
+class TestDeepAgentActivityProjectorCustom:
+    """Tests for DeepAgentActivityProjector custom stream handling."""
+
+    def test_observe_custom_dict(self):
+        sink_calls = []
+        projector = DeepAgentActivityProjector(
+            task_id="t1", run_id="r1", sink=sink_calls.append
+        )
+        projector.observe_stream_chunk(
+            {"type": "custom", "ns": ("tools:search",), "data": {"status": "starting", "topic": "搜索中"}}
+        )
+        assert len(sink_calls) == 1
+        payload = sink_calls[0]
+        assert payload["activity_kind"] == "progress"
+        assert payload["phase"] == "tool_use"
+        assert "搜索中" in payload["summary"]
+        assert payload["live"]["kind"] == "status"
+
+    def test_observe_custom_string(self):
+        sink_calls = []
+        projector = DeepAgentActivityProjector(
+            task_id="t1", run_id="r1", sink=sink_calls.append
+        )
+        projector.observe_stream_chunk(
+            {"type": "custom", "ns": (), "data": "处理完成"}
+        )
+        assert len(sink_calls) == 1
+        payload = sink_calls[0]
+        assert "处理完成" in payload["summary"]
+
+    def test_observe_custom_empty_data(self):
+        sink_calls = []
+        projector = DeepAgentActivityProjector(
+            task_id="t1", run_id="r1", sink=sink_calls.append
+        )
+        projector.observe_stream_chunk(
+            {"type": "custom", "ns": ("tools:x",), "data": None}
+        )
+        assert len(sink_calls) == 1
+        payload = sink_calls[0]
+        assert payload["title"] == "自定义进度"

--- a/backend/tests/runtime/test_deep_agent_runtime.py
+++ b/backend/tests/runtime/test_deep_agent_runtime.py
@@ -676,7 +676,7 @@ def test_deep_agent_runtime_streams_with_required_options_and_activity_events(
     }
     assert agent.kwargs["subgraphs"] is True
     assert agent.kwargs["version"] == "v2"
-    assert agent.kwargs["stream_mode"] == ["updates", "messages"]
+    assert agent.kwargs["stream_mode"] == ["updates", "messages", "custom"]
     assert [event["status"] for event in activity_events] == [
         "started",
         "running",


### PR DESCRIPTION
## 修复内容

启用 DeepAgents `custom` 流模式，让工具内部的自定义进度事件（如 `get_stream_writer()` 发送的事件）能够被正确接收和投影。

### 变更摘要

1. **`deep_agent_runtime.py`**：`stream_mode` 从 `["updates", "messages"]` 扩展为 `["updates", "messages", "custom"]`。
2. **`agent_activity.py`**：
   - `observe_stream_chunk()` 新增 `custom` 分支
   - 新增 `_observe_custom_data()` 方法，将自定义数据投影为 `deep_agent_activity` 活动事件
   - 支持 dict 格式（提取 `status`/`topic`/`message`）和字符串格式的自定义数据
3. **测试更新**：
   - 更新 `test_deep_agent_runtime_streams_with_required_options_and_activity_events` 断言
   - 新增 3 个 `DeepAgentActivityProjector` custom 事件投影测试

### 验证结果

- `uv run pytest`：215 测试全部通过
- 变更文件 ruff 检查通过

### 风险说明

低风险。纯新增事件处理分支，不改变现有 `updates`/`messages` 处理逻辑。

Closes #47
