### PR TITLE
优化命名空间路由：优先识别 tools: 前缀

### DIFF
--- a/backend/app/agent_activity.py
+++ b/backend/app/agent_activity.py
@@ -805,6 +805,13 @@ def _path_items(value: Any) -> list[str]:
 
 
 def _agent_id_from_path(path: Sequence[str]) -> str | None:
+    for item in path:
+        if isinstance(item, str) and item.startswith("tools:"):
+            sanitized, _ = _sanitize_activity_text(
+                item, max_chars=FIELD_LIMITS["agent_id"]
+            )
+            if sanitized:
+                return sanitized
     for item in reversed(path):
         sanitized, _ = _sanitize_activity_text(item, max_chars=FIELD_LIMITS["agent_id"])
         if sanitized and sanitized not in {"updates", "messages"}:

--- a/backend/tests/runtime/test_agent_activity.py
+++ b/backend/tests/runtime/test_agent_activity.py
@@ -111,3 +111,30 @@ class TestDeepAgentActivityProjectorCustom:
         assert len(sink_calls) == 1
         payload = sink_calls[0]
         assert payload["title"] == "自定义进度"
+
+
+class TestAgentIdFromPath:
+    def test_tools_prefix_first(self):
+        from app.agent_activity import _agent_id_from_path
+
+        assert _agent_id_from_path(["tools:abc123"]) == "tools:abc123"
+
+    def test_tools_prefix_among_others(self):
+        from app.agent_activity import _agent_id_from_path
+
+        assert _agent_id_from_path(["tools:abc123", "model_request:def456"]) == "tools:abc123"
+
+    def test_empty_path_returns_none(self):
+        from app.agent_activity import _agent_id_from_path
+
+        assert _agent_id_from_path([]) is None
+
+    def test_fallback_without_tools_prefix(self):
+        from app.agent_activity import _agent_id_from_path
+
+        assert _agent_id_from_path(["some_node"]) == "some_node"
+
+    def test_skips_updates_and_messages(self):
+        from app.agent_activity import _agent_id_from_path
+
+        assert _agent_id_from_path(["updates", "real_node"]) == "real_node"


### PR DESCRIPTION
## 修复内容

优化 `_agent_id_from_path()` 使其优先识别 DeepAgents 命名空间中的 `tools:` 前缀，从而正确提取子 Agent 标识。

### 变更摘要

1. **`agent_activity.py`**：
   - `_agent_id_from_path()` 改为先正向遍历路径，优先识别 `tools:` 前缀项
   - 保留原有的反向兜底逻辑（向后兼容）
   - 空路径仍返回 `None`，由 `_agent_name_from_path()`  fallback 为 `"main_agent"`

2. **测试更新**：
   - 新增 5 个单元测试覆盖 `tools:` 前缀识别、空路径、兜底逻辑

### 验证结果

- `uv run pytest`：220 测试全部通过
- 变更文件 ruff 检查通过

### 风险说明

低风险。纯解析逻辑优化，不改变现有接口或存储格式。

Closes #49
