### PR TITLE
将 tavily_search 注册为 DeepAgent 内部工具并提取共享 HTTP helper

### DIFF
--- a/backend/app/agent_profiles.py
+++ b/backend/app/agent_profiles.py
@@ -14,7 +14,7 @@ ToolRegistry = Mapping[str, Callable[..., Any]]
 
 DEFAULT_AGENT_PROFILE_ID = "default_file_agent"
 BID_MULTI_AGENT_PROFILE_ID = "bid_multi_agent"
-FILE_TOOL_ALIASES = ("list_dir", "read_file", "write_file")
+FILE_TOOL_ALIASES = ("list_dir", "read_file", "write_file", "tavily_search")
 SAFE_TOOL_ALIASES = set(FILE_TOOL_ALIASES)
 SAFE_MODEL_IDS = {str(item["id"]) for item in MODEL_REGISTRY}
 SAFE_PROFILE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -41,7 +41,7 @@ class AgentProfile:
     reason_code: str
     system_prompt_fragment: str
     subagents: tuple[SubAgentSpec, ...]
-    allowed_tool_aliases: tuple[str, ...] = ("list_dir", "read_file", "write_file")
+    allowed_tool_aliases: tuple[str, ...] = ("list_dir", "read_file", "write_file", "tavily_search")
     model_override_policy: ModelOverridePolicy = "inherit_only"
     expected_outputs: tuple[str, ...] = ()
     observability_labels: dict[str, str] = field(default_factory=dict)

--- a/backend/app/deep_agent_runtime.py
+++ b/backend/app/deep_agent_runtime.py
@@ -18,6 +18,7 @@ from .runtime import CancellationController
 from .tools import (
     AuditedWorkspaceTools,
     AuditOperation,
+    _raw_tavily_search,
     is_windows_absolute_path,
 )
 
@@ -30,6 +31,11 @@ try:
     from deepagents.backends.protocol import BackendProtocol as ImportedBackendProtocol
 except ImportError:  # pragma: no cover - optional integration dependency.
     ImportedBackendProtocol = object
+
+try:
+    from langgraph.config import get_stream_writer as _get_stream_writer
+except ImportError:
+    _get_stream_writer = None  # type: ignore[assignment]
 
 
 @dataclass
@@ -383,10 +389,12 @@ class DeepAgentRuntime:
         *,
         agent_factory: AgentFactory | None = None,
         activity_sink: ActivitySink | None = None,
+        tavily_api_key: str = "",
     ) -> None:
         self.file_tools = file_tools
         self.agent_factory = agent_factory if agent_factory is not None else _DEFAULT_AGENT_FACTORY
         self.activity_sink = activity_sink
+        self._tavily_api_key = tavily_api_key
 
     @property
     def is_available(self) -> bool:
@@ -405,7 +413,27 @@ class DeepAgentRuntime:
             """Write a UTF-8 file under records/ or outputs/ in the run workspace."""
             return self.file_tools.write_file(relative_path, content)
 
-        return [list_dir, read_file, write_file]
+        def tavily_search(query: str, max_results: int = 5) -> dict[str, Any]:
+            """Search the web using Tavily API for real-time information."""
+            try:
+                if _get_stream_writer is not None:
+                    writer = _get_stream_writer()
+                    writer({"status": "searching", "query": query, "tool": "tavily_search"})
+            except Exception:
+                pass
+            self.file_tools.controller.raise_if_cancelled()
+            result = _raw_tavily_search(query, self._tavily_api_key, max_results)
+            self.file_tools.controller.raise_if_cancelled()
+            try:
+                if _get_stream_writer is not None:
+                    writer = _get_stream_writer()
+                    result_count = len(result.get("results", []))
+                    writer({"status": "search_complete", "result_count": result_count, "tool": "tavily_search"})
+            except Exception:
+                pass
+            return result
+
+        return [list_dir, read_file, write_file, tavily_search]
 
     def run(
         self,

--- a/backend/app/orchestrator.py
+++ b/backend/app/orchestrator.py
@@ -50,6 +50,7 @@ class DeepAgentOrchestrator:
         agent_profile: AgentProfile = DEFAULT_FILE_AGENT_PROFILE,
         read_chunk_chars: int = 1024 * 1024,
         write_chunk_chars: int = 1024 * 1024,
+        tavily_api_key: str = "",
     ) -> None:
         self.storage = storage
         self.task_id = task_id
@@ -75,6 +76,7 @@ class DeepAgentOrchestrator:
             self.file_tools,
             agent_factory=agent_factory,
             activity_sink=self._append_activity,
+            tavily_api_key=tavily_api_key,
         )
 
     def run(self, message: str) -> DeepAgentRunResult:

--- a/backend/app/runner.py
+++ b/backend/app/runner.py
@@ -444,6 +444,7 @@ class TaskRunner:
                         controller=controller,
                         uploads=selected_uploads,
                         agent_profile=agent_profile,
+                        tavily_api_key=self.settings.tavily_api_key,
                     )
                     deep_agent_result = orchestrator.run(message)
                     artifact_names = deep_agent_result.metadata.get("promoted_artifacts")

--- a/backend/app/tools.py
+++ b/backend/app/tools.py
@@ -511,6 +511,23 @@ def sanitize_file_tool_reason(reason: str, workspace_root: Path) -> str:
 ALLOWED_SEARCH_SUFFIXES = {".md", ".json", ".txt"}
 
 
+def _raw_tavily_search(
+    query: str,
+    api_key: str | None,
+    max_results: int = 5,
+) -> dict[str, Any]:
+    """Shared Tavily API helper — no controller, no side effects."""
+    if not api_key:
+        return {"results": [], "warning": "未配置 TAVILY_API_KEY"}
+    response = httpx.post(
+        "https://api.tavily.com/search",
+        json={"api_key": api_key, "query": query, "max_results": max_results},
+        timeout=20,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 class WorkspaceTools:
     def __init__(
         self,
@@ -598,16 +615,9 @@ class WorkspaceTools:
 
     def tavily_search(self, query: str, max_results: int = 5) -> dict[str, Any]:
         self.controller.raise_if_cancelled()
-        if not self.tavily_api_key:
-            return {"results": [], "warning": "未配置 TAVILY_API_KEY"}
-        response = httpx.post(
-            "https://api.tavily.com/search",
-            json={"api_key": self.tavily_api_key, "query": query, "max_results": max_results},
-            timeout=20,
-        )
+        result = _raw_tavily_search(query, self.tavily_api_key, max_results)
         self.controller.raise_if_cancelled()
-        response.raise_for_status()
-        return response.json()
+        return result
 
     def _resolve(self, relative_path: str) -> Path:
         path = (self.workspace_root / relative_path).resolve()

--- a/backend/tests/runtime/test_deep_agent_runtime.py
+++ b/backend/tests/runtime/test_deep_agent_runtime.py
@@ -63,10 +63,14 @@ def fake_tool_registry() -> dict[str, Any]:
     def write_file(_relative_path: str, _content: str) -> dict[str, Any]:
         return {}
 
+    def tavily_search(_query: str, _max_results: int = 5) -> dict[str, Any]:
+        return {}
+
     return {
         "list_dir": list_dir,
         "read_file": read_file,
         "write_file": write_file,
+        "tavily_search": tavily_search,
     }
 
 
@@ -88,7 +92,7 @@ def test_agent_profile_registry_validates_static_bid_profile() -> None:
     ]
     assert [item["name"] for item in compiled] == profile.planned_subagents
     assert all(
-        tool_names(item["tools"]) == {"list_dir", "read_file", "write_file"}
+        tool_names(item["tools"]) == {"list_dir", "read_file", "write_file", "tavily_search"}
         for item in compiled
     )
 
@@ -170,7 +174,7 @@ def test_deep_agent_mock_factory_gets_audited_file_tools_without_raw_filesystem(
         assert backend.virtual_mode is True
         assert isinstance(backend, deep_agent_runtime.AuditedDeepAgentBackend)
         tool_map = {tool.__name__: tool for tool in tools}
-        assert set(tool_map) == {"list_dir", "read_file", "write_file"}
+        assert set(tool_map) == {"list_dir", "read_file", "write_file", "tavily_search"}
         assert all(not hasattr(tool, "__self__") for tool in tools)
         assert tool_names(subagents[0]["tools"]) == set(tool_map)
 

--- a/backend/tests/runtime/test_tavily_helper.py
+++ b/backend/tests/runtime/test_tavily_helper.py
@@ -1,0 +1,109 @@
+"""Tests for the shared _raw_tavily_search helper and DeepAgent tavily tool."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tools import _raw_tavily_search
+
+
+class TestRawTavilySearch:
+    """Tests for _raw_tavily_search helper."""
+
+    def test_returns_empty_when_no_key(self):
+        result = _raw_tavily_search("test query", "")
+        assert result == {"results": [], "warning": "未配置 TAVILY_API_KEY"}
+
+    def test_returns_empty_when_key_is_none(self):
+        result = _raw_tavily_search("test query", None)  # type: ignore[arg-type]
+        assert result == {"results": [], "warning": "未配置 TAVILY_API_KEY"}
+
+    @patch("app.tools.httpx.post")
+    def test_calls_tavily_api(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [{"title": "test", "url": "https://example.com"}]}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        result = _raw_tavily_search("test query", "fake-key", max_results=3)
+
+        mock_post.assert_called_once_with(
+            "https://api.tavily.com/search",
+            json={"api_key": "fake-key", "query": "test query", "max_results": 3},
+            timeout=20,
+        )
+        assert result == {"results": [{"title": "test", "url": "https://example.com"}]}
+
+    @patch("app.tools.httpx.post")
+    def test_passes_max_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        _raw_tavily_search("q", "key", max_results=10)
+
+        call_args = mock_post.call_args
+        assert call_args.kwargs["json"]["max_results"] == 10
+
+
+class TestDeepAgentTavilyTool:
+    """Tests for tavily_search in DeepAgentRuntime.build_tools()."""
+
+    def _make_runtime(self, tavily_key: str = "fake-key"):
+        from unittest.mock import MagicMock
+        from app.deep_agent_runtime import DeepAgentRuntime
+
+        mock_file_tools = MagicMock()
+        mock_file_tools.controller = MagicMock()
+        return DeepAgentRuntime(
+            mock_file_tools,
+            agent_factory=MagicMock(),  # prevent deepagents import
+            tavily_api_key=tavily_key,
+        )
+
+    def test_build_tools_includes_tavily(self):
+        runtime = self._make_runtime()
+        tools = runtime.build_tools()
+        tool_names = [t.__name__ for t in tools]
+        assert "tavily_search" in tool_names
+
+    @patch("app.deep_agent_runtime._raw_tavily_search")
+    def test_tavily_tool_delegates_to_helper(self, mock_search):
+        mock_search.return_value = {"results": [{"title": "found"}]}
+        runtime = self._make_runtime(tavily_key="test-key")
+        tools = runtime.build_tools()
+        tavily = next(t for t in tools if t.__name__ == "tavily_search")
+
+        result = tavily("test query", max_results=5)
+
+        mock_search.assert_called_once_with("test query", "test-key", 5)
+        assert result == {"results": [{"title": "found"}]}
+
+    def test_tavily_tool_checks_cancellation(self):
+        from unittest.mock import MagicMock
+
+        mock_file_tools = MagicMock()
+        mock_controller = MagicMock()
+        mock_file_tools.controller = mock_controller
+
+        from app.deep_agent_runtime import DeepAgentRuntime
+        runtime = DeepAgentRuntime(
+            mock_file_tools,
+            agent_factory=MagicMock(),
+            tavily_api_key="key",
+        )
+        tools = runtime.build_tools()
+        tavily = next(t for t in tools if t.__name__ == "tavily_search")
+
+        # First raise_if_cancelled call raises
+        mock_controller.raise_if_cancelled.side_effect = RuntimeError("cancelled")
+
+        with pytest.raises(RuntimeError, match="cancelled"):
+            tavily("query")
+
+    def test_runtime_default_tavily_key_empty(self):
+        from unittest.mock import MagicMock
+        from app.deep_agent_runtime import DeepAgentRuntime
+
+        runtime = DeepAgentRuntime(MagicMock(), agent_factory=MagicMock())
+        assert runtime._tavily_api_key == ""

--- a/backend/tests/workflow/test_workflow.py
+++ b/backend/tests/workflow/test_workflow.py
@@ -1102,7 +1102,7 @@ def test_auto_bid_prompt_selects_bid_multi_agent_profile(
         "report-writing-agent",
     ]
     assert all(
-        names == {"list_dir", "read_file", "write_file"}
+        names == {"list_dir", "read_file", "write_file", "tavily_search"}
         for names in captured_subagent_tool_names
     )
     assert run_manifest["agent_profile"]["id"] == BID_MULTI_AGENT_PROFILE_ID


### PR DESCRIPTION
## 概要

将 `tavily_search` 从仅限 `WorkspaceTools` 的方法提升为 DeepAgent 可用的内部工具，使 DeepAgent 在自主运行时可决定调用联网搜索，并通过 `get_stream_writer()` 发射实时进度。

## 变更

| 文件 | 变更 |
|------|------|
| `tools.py` | 新增模块级 `_raw_tavily_search()` 共享 helper；`WorkspaceTools.tavily_search()` 委托给它 |
| `deep_agent_runtime.py` | `__init__` 新增 `tavily_api_key`；`build_tools()` 新增 `tavily_search` tool（含 `get_stream_writer()` 进度） |
| `orchestrator.py` | 透传 `tavily_api_key` 到 `DeepAgentRuntime` |
| `runner.py` | 传递 `tavily_api_key` 到 `DeepAgentOrchestrator` |
| `agent_profiles.py` | `FILE_TOOL_ALIASES` / `allowed_tool_aliases` 加入 `tavily_search` |
| `test_tavily_helper.py` | **新增** 8 个测试覆盖 helper 和 tool 注册 |

## 不变

- `runner.py` search 路由的 emit 序列不变
- `analysis.py` 的 `_call_tool` 包装不变
- 事件格式（`search_tool_call` / `search_tool_result` / `tool_call` / `tool_result`）不变

## 验证

```
228 tests passed (含 8 个新增)
ruff 仅报历史错误
```

Closes #52