### PR TITLE
chore: 删除 7 个仅含文档字符串的占位模块

### DIFF
--- a/backend/app/agent/config.py
+++ b/backend/app/agent/config.py
@@ -1,1 +1,0 @@
-"""Agent configuration: system prompt, middleware order, subagent bindings."""

--- a/backend/app/agent/profiles.py
+++ b/backend/app/agent/profiles.py
@@ -1,1 +1,0 @@
-"""Named agent profiles (general-purpose, research, coding, etc.)."""

--- a/backend/app/backend/composite.py
+++ b/backend/app/backend/composite.py
@@ -1,1 +1,0 @@
-"""CompositeBackend: delegates to StateBackend or StoreBackend."""

--- a/backend/app/backend/store.py
+++ b/backend/app/backend/store.py
@@ -1,1 +1,0 @@
-"""StoreBackend: persistent memory via LangGraph BaseStore."""

--- a/backend/app/runner/events.py
+++ b/backend/app/runner/events.py
@@ -1,1 +1,0 @@
-"""Event emission helpers for task runner."""

--- a/backend/app/runner/lifecycle.py
+++ b/backend/app/runner/lifecycle.py
@@ -1,1 +1,0 @@
-"""Task lifecycle state machine: idle -> running -> complete/failed."""

--- a/backend/app/streaming/projector.py
+++ b/backend/app/streaming/projector.py
@@ -1,1 +1,0 @@
-"""Project streaming events into task state updates."""


### PR DESCRIPTION
## 变更

删除 7 个仅含文档字符串的占位 Python 模块，这些模块无实现、无导入引用、无测试：

- `app/agent/config.py`
- `app/agent/profiles.py`
- `app/backend/composite.py`
- `app/backend/store.py`
- `app/runner/events.py`
- `app/runner/lifecycle.py`
- `app/streaming/projector.py`

## 影响文件

- 删除上述 7 个文件

## 验证

- [x] 搜索确认无任何模块导入这些文件
- [x] `uv run pytest` 40/40 通过
- [x] `uv run ruff check .` 通过
- [x] `uv run mypy app tests` 无新增错误
- [x] 未引入行为变更

Closes #58
