### PR TITLE
fix: 收紧依赖版本上界、移除已弃用 deepseek_timeout_seconds 配置

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,9 +39,6 @@ class Settings:
     max_upload_request_bytes: int = 101 * 1024 * 1024
     max_json_request_bytes: int = 64 * 1024
 
-    # Deprecated but kept for backward compatibility
-    deepseek_timeout_seconds: float = 15.0
-
 
 MODEL_REGISTRY = [
     {
@@ -130,7 +127,6 @@ def load_settings() -> Settings:
             64 * 1024,
             "AGENT_CHAT_MAX_JSON_REQUEST_BYTES",
         ),
-        deepseek_timeout_seconds=read_float_env("DEEPSEEK_TIMEOUT_SECONDS", 15.0),
     )
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,13 +9,13 @@ dependencies = [
   "python-multipart>=0.0.26,<1.0.0",
   "httpx>=0.27.0,<1.0.0",
   "pydantic>=2.0,<3.0.0",
-  "langchain>=0.3",
-  "langgraph>=0.3",
-  "deepagents>=0.5",
-  "langchain-openai>=0.3",
-  "langchain-anthropic>=0.3",
-  "langchain-deepseek>=0.1",
-  "tavily-python>=0.5",
+  "langchain>=0.3,<2.0.0",
+  "langgraph>=0.3,<2.0.0",
+  "deepagents>=0.5,<2.0.0",
+  "langchain-openai>=0.3,<2.0.0",
+  "langchain-anthropic>=0.3,<2.0.0",
+  "langchain-deepseek>=0.1,<2.0.0",
+  "tavily-python>=0.5,<1.0.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

修复 Issue #66 剩余的维护项。

### 变更内容

1. **依赖版本上界收紧** (`pyproject.toml`)
   - 所有 langchain/langgraph 系列依赖添加 `<2.0.0` 上界
   - 上界与 `deepagents 0.5.7` 传递依赖约束 (`langchain>=1.2.17,<2.0.0`) 对齐
   - 防止未来 major 版本 breaking changes 静默引入

2. **移除已弃用配置** (`config.py`)
   - 删除 `deepseek_timeout_seconds` 字段（标注为 deprecated 但无任何模块引用）
   - 删除 `load_settings()` 中对应的 `read_float_env` 调用
   - `DEEPSEEK_TIMEOUT_SECONDS` 环境变量不再生效

### 验证

- ✅ `uv run ruff check app/` — All checks passed
- ✅ `uv run mypy app tests` — Success: no issues found in 67 source files
- ✅ `uv run pytest` — 72 passed, 1 warning

Closes #66