### PR TITLE
fix(api): 修复新建任务发送消息返回 404 "任务不存在" 的严重 bug

### DIFF
--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -21,9 +21,10 @@ def _runner(request: Request):
 def upload_files(task_id: str, files: list[UploadFile], request: Request) -> TaskState:
     storage = _storage(request)
     runner = _runner(request)
-    state = storage.get_task(task_id, include_events=False)
-    if state.status == "idle" and not state.messages:
-        raise HTTPException(status_code=404, detail="任务不存在")
+    try:
+        storage.get_task(task_id, include_events=False)
+    except (FileNotFoundError, ValueError):
+        raise HTTPException(status_code=404, detail="任务不存在") from None
     if runner.is_running(task_id):
         raise HTTPException(status_code=409, detail="任务运行中不能上传文件")
     settings = request.app.state.settings

--- a/backend/app/api/streaming.py
+++ b/backend/app/api/streaming.py
@@ -47,9 +47,10 @@ async def _event_stream(task_id: str, request: Request) -> AsyncGenerator[str, N
 @router.get("/{task_id}/stream")
 def stream_task(task_id: str, request: Request) -> StreamingResponse:
     storage = _storage(request)
-    state = storage.get_task(task_id, include_events=False)
-    if state.status == "idle" and not state.messages:
-        raise HTTPException(status_code=404, detail="任务不存在")
+    try:
+        storage.get_task(task_id, include_events=False)
+    except (FileNotFoundError, ValueError):
+        raise HTTPException(status_code=404, detail="任务不存在") from None
     return StreamingResponse(
         _event_stream(task_id, request),
         media_type="text/event-stream",

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -23,13 +23,28 @@ def _runner(request: Request):
     return request.app.state.runner
 
 
+def _get_existing_task(storage, task_id: str, **kwargs) -> TaskState:
+    """Read task state; return 404 if the task directory does not exist."""
+    try:
+        return storage.get_task(task_id, **kwargs)
+    except (FileNotFoundError, ValueError):
+        raise HTTPException(status_code=404, detail="任务不存在") from None
+
+
 @router.post("", response_model=TaskState, status_code=201)
 def create_task(body: TaskCreateRequest, request: Request) -> TaskState:
     storage = _storage(request)
+    runner = _runner(request)
     state = storage.create_task(message=None, model=body.model)
     if body.message:
-        runner = _runner(request)
-        runner.start_background(state.task_id, body.message, model=body.model)
+        run_result = storage.start_run(
+            state.task_id,
+            message=body.message,
+            model=body.model,
+            expected_statuses={"idle"},
+        )
+        if run_result is not None:
+            runner.start_background(state.task_id, body.message, model=body.model)
     return storage.get_task(state.task_id)
 
 
@@ -40,19 +55,13 @@ def list_tasks(request: Request) -> list[TaskSummary]:
 
 @router.get("/{task_id}", response_model=TaskState)
 def get_task(task_id: str, request: Request) -> TaskState:
-    storage = _storage(request)
-    state = storage.get_task(task_id)
-    if state.status == "idle" and not state.messages:
-        raise HTTPException(status_code=404, detail="任务不存在")
-    return state
+    return _get_existing_task(_storage(request), task_id)
 
 
 @router.get("/{task_id}/events", response_model=list[EventRecord])
 def get_events(task_id: str, request: Request, after_id: str | None = None) -> list[EventRecord]:
     storage = _storage(request)
-    state = storage.get_task(task_id, include_events=False)
-    if state.status == "idle" and not state.messages:
-        raise HTTPException(status_code=404, detail="任务不存在")
+    _get_existing_task(storage, task_id, include_events=False)
     return storage.read_events(task_id, after_id=after_id)
 
 
@@ -60,11 +69,17 @@ def get_events(task_id: str, request: Request, after_id: str | None = None) -> l
 def send_message(task_id: str, body: MessageRequest, request: Request) -> TaskState:
     storage = _storage(request)
     runner = _runner(request)
-    state = storage.get_task(task_id, include_events=False)
-    if state.status == "idle" and not state.messages:
-        raise HTTPException(status_code=404, detail="任务不存在")
+    _get_existing_task(storage, task_id, include_events=False)
     if runner.is_running(task_id):
         raise HTTPException(status_code=409, detail="任务运行中，请等待完成后再发送消息")
+    run_result = storage.start_run(
+        task_id,
+        message=body.message,
+        model=body.model,
+        expected_statuses={"idle", "complete", "failed", "cancelled", "needs_input", "interrupted"},
+    )
+    if run_result is None:
+        raise HTTPException(status_code=409, detail="任务状态不允许发送消息")
     runner.start_background(task_id, body.message, model=body.model)
     return storage.get_task(task_id)
 
@@ -73,9 +88,7 @@ def send_message(task_id: str, body: MessageRequest, request: Request) -> TaskSt
 async def cancel_task(task_id: str, request: Request) -> TaskState:
     storage = _storage(request)
     runner = _runner(request)
-    state = storage.get_task(task_id, include_events=False)
-    if state.status == "idle" and not state.messages:
-        raise HTTPException(status_code=404, detail="任务不存在")
+    _get_existing_task(storage, task_id, include_events=False)
     if not runner.is_running(task_id):
         raise HTTPException(status_code=409, detail="任务未在运行中")
     await runner.cancel(task_id)

--- a/backend/tests/unit/api/test_tasks.py
+++ b/backend/tests/unit/api/test_tasks.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.config import Settings
+
+
+@pytest.fixture
+def app_client(tmp_path):
+    settings = Settings(
+        task_root=tmp_path / "tasks",
+        workspace_root=tmp_path / "tasks",
+    )
+    app = create_app(settings)
+    return TestClient(app)
+
+
+@pytest.fixture
+def create_idle_task(app_client):
+    def _create(model="deepseek:deepseek-chat"):
+        response = app_client.post(
+            "/api/tasks",
+            json={"model": model},
+        )
+        assert response.status_code == 201
+        return response.json()
+
+    return _create
+
+
+class TestCreateTask:
+    def test_create_task_returns_201(self, app_client):
+        response = app_client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"})
+        assert response.status_code == 201
+        data = response.json()
+        assert data["status"] == "idle"
+        assert data["task_id"]
+        assert data["model"] == "deepseek:deepseek-chat"
+
+    def test_create_task_without_message_is_idle(self, app_client):
+        response = app_client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"})
+        data = response.json()
+        assert data["status"] == "idle"
+        assert data["messages"] == []
+
+
+class TestGetTask:
+    def test_get_idle_task_returns_state(self, create_idle_task, app_client):
+        created = create_idle_task()
+        response = app_client.get(f"/api/tasks/{created['task_id']}")
+        assert response.status_code == 200
+        assert response.json()["task_id"] == created["task_id"]
+
+    def test_get_nonexistent_task_returns_404(self, app_client):
+        response = app_client.get("/api/tasks/nonexistent-id")
+        assert response.status_code == 404
+
+    def test_newly_created_task_is_accessible(self, app_client):
+        create_resp = app_client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"})
+        task_id = create_resp.json()["task_id"]
+        get_resp = app_client.get(f"/api/tasks/{task_id}")
+        assert get_resp.status_code == 200
+        state = get_resp.json()
+        assert state["status"] == "idle"
+        assert state["messages"] == []
+
+
+class TestGetEvents:
+    def test_get_events_for_idle_task(self, create_idle_task, app_client):
+        created = create_idle_task()
+        response = app_client.get(f"/api/tasks/{created['task_id']}/events")
+        assert response.status_code == 200
+        events = response.json()
+        assert isinstance(events, list)
+        assert any(e["type"] == "task_created" for e in events)
+
+    def test_get_events_nonexistent_task_404(self, app_client):
+        response = app_client.get("/api/tasks/nonexistent-id/events")
+        assert response.status_code == 404
+
+
+class TestSendMessage:
+    def test_send_message_to_idle_task_succeeds(self, create_idle_task, app_client):
+        created = create_idle_task()
+        runner = app_client.app.state.runner
+        original_start = runner.start_background
+
+        def mock_start_background(*args, **kwargs):
+            pass
+
+        runner.start_background = mock_start_background
+        try:
+            response = app_client.post(
+                f"/api/tasks/{created['task_id']}/messages",
+                json={"message": "hello", "model": "deepseek:deepseek-chat"},
+            )
+        finally:
+            runner.start_background = original_start
+
+        assert response.status_code == 200
+        state = response.json()
+        assert state["status"] == "running"
+        assert any(m["role"] == "user" for m in state["messages"])
+
+    def test_send_message_to_nonexistent_task_404(self, app_client):
+        response = app_client.post(
+            "/api/tasks/nonexistent-id/messages",
+            json={"message": "hello", "model": "deepseek:deepseek-chat"},
+        )
+        assert response.status_code == 404
+
+    def test_send_message_adds_user_message(self, create_idle_task, app_client):
+        created = create_idle_task()
+        runner = app_client.app.state.runner
+        original_start = runner.start_background
+
+        def mock_start_background(*args, **kwargs):
+            pass
+
+        runner.start_background = mock_start_background
+        try:
+            response = app_client.post(
+                f"/api/tasks/{created['task_id']}/messages",
+                json={"message": "test message content", "model": "deepseek:deepseek-chat"},
+            )
+        finally:
+            runner.start_background = original_start
+
+        assert response.status_code == 200
+        messages = response.json()["messages"]
+        user_messages = [m for m in messages if m["role"] == "user"]
+        assert len(user_messages) == 1
+        assert user_messages[0]["content"] == "test message content"
+
+
+class TestUploadFiles:
+    def test_upload_to_idle_task_succeeds(self, create_idle_task, app_client):
+        created = create_idle_task()
+        response = app_client.post(
+            f"/api/tasks/{created['task_id']}/files",
+            files={"files": ("test.md", b"# test content", "text/markdown")},
+        )
+        assert response.status_code == 201
+
+    def test_upload_to_nonexistent_task_404(self, app_client):
+        response = app_client.post(
+            "/api/tasks/nonexistent-id/files",
+            files={"files": ("test.md", b"# test", "text/markdown")},
+        )
+        assert response.status_code == 404
+
+
+class TestCancelTask:
+    def test_cancel_idle_task_returns_409(self, create_idle_task, app_client):
+        created = create_idle_task()
+        response = app_client.post(f"/api/tasks/{created['task_id']}/cancel")
+        assert response.status_code == 409
+
+    def test_cancel_nonexistent_task_404(self, app_client):
+        response = app_client.post("/api/tasks/nonexistent-id/cancel")
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

- 修复新建任务发送消息或上传文件时返回 404 "任务不存在" 的严重 bug
- 修复 `send_message` 端点不调用 `storage.start_run()` 导致任务状态不转换的问题
- 新增 14 个 API 端点测试

## Changes

### Bug #1: "任务不存在" 误判 (Critical)

**根因**：6 个 API 端点共享了过于激进的检查 `if state.status == "idle" and not state.messages: raise 404`。新建任务必定是 `idle` 且 `messages=[]`，导致前端提交流程中任何后续 API 调用都返回 404。

**修复**：
- `tasks.py`：新增 `_get_existing_task()` 辅助函数，通过捕获 `FileNotFoundError`/`ValueError` 判断任务是否存在，而非检查内容
- `files.py`：同样改用异常捕获判断任务存在性
- `streaming.py`：同样改用异常捕获判断任务存在性
- 移除所有 `state.status == "idle" and not state.messages` 检查

### Bug #2: 任务状态不转换 (High)

**根因**：`send_message` 和 `create_task` 端点直接调用 `runner.start_background()` 启动 agent，但从不调用 `storage.start_run()` 来将任务状态从 `idle` 转换为 `running`。

**修复**：
- `send_message`：在调用 `runner.start_background()` 前先调用 `storage.start_run()`，原子性地转换状态、添加用户消息、创建运行记录
- `create_task`：当 body 包含 message 时，同样先调用 `storage.start_run()`

## Test Plan

新增 `tests/unit/api/test_tasks.py`（14 个测试）：
- `TestCreateTask`：创建任务返回 201、无消息时为 idle
- `TestGetTask`：idle 任务返回 200、不存在返回 404、新建任务可访问
- `TestGetEvents`：idle 任务返回事件列表、不存在返回 404
- `TestSendMessage`：idle 任务发送消息成功（状态变为 running）、不存在返回 404、添加用户消息
- `TestUploadFiles`：idle 任务上传文件成功、不存在返回 404
- `TestCancelTask`：idle 任务返回 409、不存在返回 404

全部 86 个测试通过。

## Verification

```bash
cd backend
uv run pytest          # 86 passed
uv run ruff check .    # All checks passed
uv run mypy app tests  # Success
```

Closes #72
