### PR TITLE
修复(security): 限制文件系统工具到当前任务目录

### DIFF
--- a/backend/app/runner/core.py
+++ b/backend/app/runner/core.py
@@ -43,10 +43,13 @@ class TaskRunner:
         run_id = str(uuid.uuid4())
         model_id = model or self.settings.default_model
 
+        task_workspace = self.settings.workspace_root / task_id
+        tools = get_platform_tools(self.settings, task_workspace=task_workspace)
+
         agent = build_agent(
             self.settings,
             model=model_id,
-            tools=get_platform_tools(self.settings),
+            tools=tools,
             skills=list(self.settings.skills_dirs),
         )
 

--- a/backend/app/tools/registry.py
+++ b/backend/app/tools/registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from langchain_core.tools import BaseTool
 
 from app.config import Settings
@@ -9,15 +11,24 @@ from app.tools.filesystem_bridge import _make_fs_tools
 from app.tools.tavily_search import tavily_search
 
 
-def get_platform_tools(settings: Settings) -> list[BaseTool]:
+def get_platform_tools(
+    settings: Settings, *, task_workspace: Path | None = None
+) -> list[BaseTool]:
     """Return all platform tools available for agent construction.
 
     Filesystem tools are always included.  The Tavily search tool is included
     only when ``settings.tavily_api_key`` is configured.
+
+    Args:
+        settings: Application settings.
+        task_workspace: Optional task-specific workspace directory. When provided,
+            filesystem tools are scoped to this directory instead of the global
+            ``settings.workspace_root``.
     """
     tools: list[BaseTool] = []
 
-    read_file, write_file, list_files = _make_fs_tools(settings.workspace_root)
+    workspace = task_workspace or settings.workspace_root
+    read_file, write_file, list_files = _make_fs_tools(workspace)
     tools.extend([read_file, write_file, list_files])
 
     if settings.tavily_api_key:


### PR DESCRIPTION
## 变更

将文件系统工具的 workspace_root 从全局 `sessions/` 目录改为当前任务目录 `sessions/{task_id}/`，防止 agent 跨任务读写文件。

## 影响文件

- `backend/app/tools/registry.py` — `get_platform_tools` 新增 `task_workspace` 参数
- `backend/app/runner/core.py` — 构建 `task_workspace` 并传入工具工厂

## 验证

- [x] `uv run ruff check` 通过
- [x] `uv run mypy` 通过
- [x] `uv run pytest` — 86 passed
- [x] 未引入无关变更

Closes #76
