### PR TITLE
修复(audit): 收敛任务运行契约与依赖风险

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,8 @@ backend/storage/tasks/*
 
 audits/
 .playwright-mcp/
-frontend/e2e-playwright/
+frontend/.next-dev-e2e/
+frontend/test-results/
+frontend/e2e-playwright/e2e-*/
+frontend/e2e-playwright/test-results/
+frontend/e2e-playwright/playwright-report/

--- a/asset/deepagents_platform_knowledge_pack.md
+++ b/asset/deepagents_platform_knowledge_pack.md
@@ -15,7 +15,8 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - Skills and SubAgents are passed via `create_deep_agent(skills=..., subagents=...)` keyword arguments, not via the middleware parameter.
 - Multi-model support uses `langchain.chat_models.init_chat_model` with `provider:model-name` format (e.g., `deepseek:deepseek-chat`, `openai:gpt-4o`, `anthropic:claude-sonnet-4-20250514`).
 - The model provider parses the provider prefix, validates the API key is configured, and creates the appropriate `BaseChatModel` instance.
-- `MODEL_REGISTRY` in `config.py` lists all supported models. The `/api/models` endpoint returns models with an `available` flag based on whether the provider API key is configured.
+- `MODEL_REGISTRY` in `config.py` lists all supported models. The `/api/models` endpoint returns models with an `available` flag based on whether the provider API key is configured. Task creation with an immediate message and follow-up message sending must reject unknown models and reject unavailable provider-backed models before scheduling a run; draft task creation without a message only needs registry validation.
+- Frontend default and fallback model IDs must also use the provider-prefixed registry format. A stale fallback such as `deepseek-reasoner` can still reach the backend when model-list loading fails or a user sends before refresh completes.
 - Default model is `deepseek:deepseek-chat` (configurable via `MYAGENT_DEFAULT_MODEL` env var).
 - Tools are LangChain `@tool` decorated functions: `read_file`, `write_file`, `list_files` (filesystem) and `tavily_search` (conditional on `TAVILY_API_KEY`).
 - Filesystem tools validate paths stay within `workspace_root` for security.
@@ -24,11 +25,12 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - Streaming uses `agent.astream(input, stream_mode=["messages", "updates"], version="v2")` via the v2 adapter (`v2_adapter.py`). LangGraph v2 returns chunks as **dicts** with keys `{type, ns, data}`, not `(namespace, mode, payload)` tuples. The adapter must handle both formats for robustness. Events are converted to `EventRecord` objects via `event_converter.py`.
 - SSE endpoint at `GET /api/tasks/{task_id}/stream` provides real-time output. Frontend uses `EventSource` API with token as query parameter.
 - SSE `_event_stream` polls `storage.read_events(task_id, after_id=last_event_id)` every 0.5s. `last_event_id` must be initialized to `None` (not `""`) so the first poll returns all existing events. An empty string causes `read_events` to skip every event because `after_id is None` evaluates to `False` and no event has `id == ""`.
-- `TaskRunner` manages agent lifecycle: build agent → stream events → convert → collect → persist events to storage → update task status. `TaskRunner.__init__` requires both `settings` and `storage` (injected from `main.py`). `start_background()` accepts `run_id` from `storage.start_run()` to ensure unified run_id across storage and streaming events. After agent execution, events are persisted via `storage.append_event()` and task status is updated to terminal state (`complete`/`failed`/`cancelled`). Supports cancellation via `cancel()`. Enforces `settings.agent_timeout_seconds` via `asyncio.timeout()`.
+- `TaskRunner` manages agent lifecycle: build agent → stream events → convert → collect → persist events to storage → update task status. `TaskRunner.__init__` requires both `settings` and `storage` (injected from `main.py`). `start_background()` accepts `run_id` from `storage.start_run()` to ensure unified run_id across storage and streaming events. After agent execution, events are persisted via `storage.append_event()` and task status is updated to terminal state (`complete`/`failed`/`cancelled`). The runner also writes run-scoped terminal events (`task_completed`, `task_failed`, `task_cancelled`) together with the terminal status update, so the UI can correlate completion, failure, or cancellation with the active run. Supports cancellation via `cancel()`. Enforces `settings.agent_timeout_seconds` via `asyncio.timeout()`.
 - `create_app()` uses FastAPI `lifespan` instead of `@app.on_event("startup")`. Startup interruption of stale running tasks must stay inside that lifespan handler, and tests that need startup side effects must enter `TestClient` as a context manager (`with TestClient(app):`).
-- API endpoints `create_task` and `send_message` are `async def` to allow `asyncio.create_task` on the event loop. `cancel_task` syncs storage status after `runner.cancel()`.
+- API endpoints `create_task` and `send_message` are `async def` to allow `asyncio.create_task` on the event loop. `cancel_task` delegates terminal status and event persistence to `TaskRunner.cancel()`/the running background task rather than appending a second unscoped cancellation event.
 - Filesystem tools are scoped to per-task workspace (`settings.workspace_root / task_id`), not the global sessions root. This prevents cross-task file access.
-- Task API routes follow REST conventions: `POST /api/tasks` (create), `GET /api/tasks` (list), `GET /api/tasks/{id}` (read), `POST /api/tasks/{id}/messages` (send message), `POST /api/tasks/{id}/cancel` (cancel).
+- Task API routes follow REST conventions: `POST /api/tasks` (create), `GET /api/tasks` (list), `GET /api/tasks/{id}` (read), `POST /api/tasks/{id}/messages` (send message), `POST /api/tasks/{id}/cancel` (cancel). `GET /api/tasks/{id}?include_events=false` is the lightweight refresh path and must return the same task shape with an empty `events` list. Artifact routes are first-class API routes: `GET /api/tasks/{id}/artifacts/{name}` for latest or legacy artifacts and `GET /api/tasks/{id}/runs/{run_id}/artifacts/{name}` for run-scoped artifacts.
+- Upload validation errors must map to stable client-facing HTTP status codes: duplicate filename conflicts return 409, size/count/request limits return 413, unsupported extensions or invalid JSON content return 400, and missing tasks return 404. The storage layer may raise domain exceptions, but API routes must not leak these as 500 responses.
 - Auth middleware enforces loopback-only access by default; non-local access requires `MYAGENT_ACCESS_TOKEN`.
 - Frontend local development keeps `next dev` output in `.next-dev` and production builds in `.next` via `NEXT_DIST_DIR`, so dev caches and production build artifacts never share one output directory.
 - Frontend type checking runs `next typegen && tsc --noEmit`; `next-env.d.ts` is generated and ignored instead of being version-controlled.
@@ -41,7 +43,9 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 ## Input And Output Examples
 
 - Create task: `POST /api/tasks` → `{"task_id": "...", "status": "idle", "model": "deepseek:deepseek-chat", ...}`
+- Lightweight task refresh: `GET /api/tasks/{id}?include_events=false` → same task state shape with `"events": []`
 - Send message: `POST /api/tasks/{id}/messages` body: `{"message": "搜索最新的AI新闻", "model": "deepseek:deepseek-chat"}`
+- Download artifact: `GET /api/tasks/{id}/runs/{run_id}/artifacts/report.html` → `FileResponse` with the artifact MIME type and safe filename.
 - Build agent: `build_agent(settings, tools=get_platform_tools(settings), skills=["./skills"])`
 - Model ID format: `"deepseek:deepseek-chat"`, `"openai:gpt-4o"`, `"anthropic:claude-sonnet-4-20250514"`
 - SSE event: `event: message\ndata: {"type": "agent_message", "text": "..."}\n\n`
@@ -52,6 +56,8 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - `storage.py` depends on compatibility shims in `app/contracts/__init__.py` and `app/reasoning_trace.py` that recreate deleted module types. These shims must not be removed until storage.py is rewritten.
 - `schemas.py` inlines `TaskMode` and `InputScope` Literal types (previously from deleted `intent.py`).
 - Missing API keys cause graceful errors in provider (not crashes). Tavily tool returns error string if key missing.
+- Missing provider API keys make affected models unavailable at `/api/models` and must block run-starting requests before background scheduling. This avoids creating task runs that are guaranteed to fail only after storage state changes.
+- Artifact names are normalized file names only, not paths. Artifact download routes must resolve through `TaskStorage.resolve_artifact()` or `TaskStorage.resolve_run_artifact()` so path traversal and cross-run access stay blocked.
 - `SKILL.md` files without valid YAML frontmatter are silently skipped during discovery.
 - `next typegen` loads `next.config.mjs` with the production build phase; keep any required config inputs available before running frontend type checks in CI.
 - Remote CI status is part of the verification boundary for GitHub actions such as PR creation and merge. A pending run is not a pass, and a warning that escalates to job failure must be fixed the same as an error.
@@ -61,6 +67,10 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - **Middleware duplication**: Never pass `TodoListMiddleware`, `FilesystemMiddleware`, `SummarizationMiddleware`, or `PatchToolCallsMiddleware` via the `middleware` param — `create_deep_agent` auto-injects them.
 - **Provider prefix**: Model IDs must include provider prefix (`deepseek:`, `openai:`, `anthropic:`). Raw model names will fail.
 - **EventSource auth**: Browser `EventSource` API doesn't support custom headers; token must be passed as query parameter `?token=xxx` for SSE. Backend `authorize_task_request` reads token from headers (`X-MyAgent-Token`, `X-Agent-Chat-Token`, `Authorization: Bearer`) and query param.
+- **SSE frontend backoff**: Browser-side SSE reconnect must be capped and use exponential backoff. Any backend SSE payload shaped as `{type: "error", detail: "..."}` is user-visible and should stop normal event processing for that message, then refresh task state defensively.
+- **Run-scoped terminal events**: Do not append terminal events from API endpoints after calling the runner. The runner owns terminal status plus terminal event writes so the `run_id` stays consistent and duplicate unscoped events are not produced.
+- **Artifact route drift**: Frontend artifact cards depend on `ArtifactRecord.url` pointing to real backend routes. Adding new artifact storage locations requires updating both the URL generator and the corresponding FastAPI download route.
+- **Upload exception leakage**: Storage upload validation exceptions should be translated by the API layer. A malformed user upload is a 4xx client error, never an unhandled 500.
 - **storage.py coupling**: TaskStorage is deeply coupled to old contracts/reasoning_trace types via compatibility shims. A future storage rewrite should use native DeepAgents state management.
 - **Single-process runtime**: The platform uses in-process runner and local JSON storage. Multi-worker deployment will break.
 - **Timeout enforcement**: `TaskRunner.start()` enforces `settings.agent_timeout_seconds` via `asyncio.timeout()`. If the deepagents SDK or LLM call hangs, the run is terminated after the configured timeout and a warning is logged.
@@ -82,7 +92,7 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - Runner: `backend/app/runner/core.py`
 - SubAgents: `backend/app/subagents/definitions.py`, `backend/app/subagents/registry.py`
 - Skills: `backend/app/skills/loader.py`, `backend/app/skills/registry.py`
-- API routes: `backend/app/api/tasks.py`, `backend/app/api/files.py`, `backend/app/api/streaming.py`, `backend/app/api/models.py`
+- API routes: `backend/app/api/tasks.py`, `backend/app/api/files.py`, `backend/app/api/artifacts.py`, `backend/app/api/streaming.py`, `backend/app/api/models.py`
 - Entry point: `backend/app/main.py`
 - Skills directory: `backend/skills/web_research/SKILL.md`, `backend/skills/code_review/SKILL.md`
 - Compatibility shims: `backend/app/contracts/__init__.py`, `backend/app/reasoning_trace.py`
@@ -105,6 +115,7 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
   - `backend/tests/unit/security/`
   - `backend/tests/unit/storage/`
   - `backend/tests/unit/session/`
+- Runtime contract tests: `backend/tests/unit/api/test_artifacts.py`, `backend/tests/unit/api/test_models.py`, `backend/tests/unit/api/test_tasks.py`, `backend/tests/unit/runner/test_core.py`, `frontend/tests/state/test_task_state.test.ts`, `frontend/tests/workspace/test_task_workspace.test.ts`
 - Integration tests: `backend/tests/integration/`
 - E2E tests: `backend/tests/e2e/test_streaming_e2e.py`
 - Frontend tests:
@@ -173,6 +184,11 @@ If the task includes pushing a branch, opening/updating a PR, or merging a PR, a
 - Middleware duplication if future developer re-adds default middleware to the stack.
 - storage.py breakage if compatibility shims are deleted without rewriting storage.
 - Model format mismatch if frontend sends old-style `deepseek-reasoner` instead of `deepseek:deepseek-chat`.
+- Model availability regression if `/api/models` stops exposing `available` or task/message endpoints schedule runs for unavailable providers.
+- Artifact download regression if `ArtifactRecord.url` no longer matches FastAPI routes or run-scoped artifacts fall back to the latest legacy artifact.
+- Upload API regression if duplicate names, limits, unsupported extensions, or invalid JSON again surface as 500 responses.
+- Terminal event regression if complete/failed/cancelled runs stop writing run-scoped terminal events, causing frontend run timelines to lose their closing signal.
+- SSE resilience regression if frontend reconnect loops become unbounded or backend SSE error payloads are ignored.
 - SSE auth bypass if EventSource query param support is removed without alternative auth.
 - Timeout breakage if `asyncio.timeout()` is removed without an alternative mechanism to prevent runaway agent runs.
 - Concurrency risk if `max_concurrent_subagents` is changed without testing subagent parallel execution limits.

--- a/backend/app/api/artifacts.py
+++ b/backend/app/api/artifacts.py
@@ -1,0 +1,49 @@
+"""Task artifact download endpoints."""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from starlette.responses import FileResponse
+
+router = APIRouter(prefix="/api/tasks", tags=["artifacts"])
+
+
+def _storage(request: Request):
+    return request.app.state.storage
+
+
+def _artifact_response(path: Path) -> FileResponse:
+    media_type, _ = mimetypes.guess_type(path.name)
+    return FileResponse(path, media_type=media_type or "application/octet-stream", filename=path.name)
+
+
+def _resolve_or_404(resolve) -> Path:
+    try:
+        return resolve()
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="产物不存在") from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+
+@router.get("/{task_id}/artifacts/{artifact_name}")
+def download_artifact(task_id: str, artifact_name: str, request: Request) -> FileResponse:
+    storage = _storage(request)
+    path = _resolve_or_404(lambda: storage.resolve_artifact(task_id, artifact_name))
+    return _artifact_response(path)
+
+
+@router.get("/{task_id}/runs/{run_id}/artifacts/{artifact_name}")
+def download_run_artifact(
+    task_id: str,
+    run_id: str,
+    artifact_name: str,
+    request: Request,
+) -> FileResponse:
+    storage = _storage(request)
+    path = _resolve_or_404(lambda: storage.resolve_run_artifact(task_id, run_id, artifact_name))
+    return _artifact_response(path)
+

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request, UploadFile
 
 from app.schemas import TaskState
+from app.storage import UploadConflictError, UploadLimitError
 
 router = APIRouter(prefix="/api/tasks", tags=["files"])
 
@@ -28,11 +29,18 @@ def upload_files(task_id: str, files: list[UploadFile], request: Request) -> Tas
     if runner.is_running(task_id):
         raise HTTPException(status_code=409, detail="任务运行中不能上传文件")
     settings = request.app.state.settings
-    storage.save_uploads(
-        task_id,
-        files,
-        max_files=settings.max_upload_files,
-        max_file_bytes=settings.max_upload_file_bytes,
-        max_request_bytes=settings.max_upload_request_bytes,
-    )
+    try:
+        storage.save_uploads(
+            task_id,
+            files,
+            max_files=settings.max_upload_files,
+            max_file_bytes=settings.max_upload_file_bytes,
+            max_request_bytes=settings.max_upload_request_bytes,
+        )
+    except UploadConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except UploadLimitError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return storage.get_task(task_id)

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
+from app.config import Settings
+from app.models.registry import is_model_available, validate_model
 from app.schemas import (
     EventRecord,
     MessageRequest,
@@ -23,6 +25,10 @@ def _runner(request: Request):
     return request.app.state.runner
 
 
+def _settings(request: Request) -> Settings:
+    return request.app.state.settings
+
+
 def _get_existing_task(storage, task_id: str, **kwargs) -> TaskState:
     """Read task state; return 404 if the task directory does not exist."""
     try:
@@ -31,10 +37,26 @@ def _get_existing_task(storage, task_id: str, **kwargs) -> TaskState:
         raise HTTPException(status_code=404, detail="任务不存在") from None
 
 
+def _validate_registered_model(model: str) -> None:
+    if not validate_model(model):
+        raise HTTPException(status_code=400, detail="模型不在允许列表中")
+
+
+def _validate_runnable_model(model: str, settings: Settings) -> None:
+    _validate_registered_model(model)
+    if not is_model_available(model, settings):
+        raise HTTPException(status_code=400, detail="模型服务未配置，请先在后端配置对应 API Key")
+
+
 @router.post("", response_model=TaskState, status_code=201)
 async def create_task(body: TaskCreateRequest, request: Request) -> TaskState:
     storage = _storage(request)
     runner = _runner(request)
+    settings = _settings(request)
+    if body.message:
+        _validate_runnable_model(body.model, settings)
+    else:
+        _validate_registered_model(body.model)
     state = storage.create_task(message=None, model=body.model)
     if body.message:
         run_result = storage.start_run(
@@ -55,8 +77,8 @@ def list_tasks(request: Request) -> list[TaskSummary]:
 
 
 @router.get("/{task_id}", response_model=TaskState)
-def get_task(task_id: str, request: Request) -> TaskState:
-    return _get_existing_task(_storage(request), task_id)
+def get_task(task_id: str, request: Request, include_events: bool = True) -> TaskState:
+    return _get_existing_task(_storage(request), task_id, include_events=include_events)
 
 
 @router.get("/{task_id}/events", response_model=list[EventRecord])
@@ -70,6 +92,7 @@ def get_events(task_id: str, request: Request, after_id: str | None = None) -> l
 async def send_message(task_id: str, body: MessageRequest, request: Request) -> TaskState:
     storage = _storage(request)
     runner = _runner(request)
+    _validate_runnable_model(body.model, _settings(request))
     _get_existing_task(storage, task_id, include_events=False)
     if runner.is_running(task_id):
         raise HTTPException(status_code=409, detail="任务运行中，请等待完成后再发送消息")
@@ -94,6 +117,4 @@ async def cancel_task(task_id: str, request: Request) -> TaskState:
     if not runner.is_running(task_id):
         raise HTTPException(status_code=409, detail="任务未在运行中")
     await runner.cancel(task_id)
-    storage.update_task_if_status(task_id, {"running"}, status="cancelled")
-    storage.append_event(task_id, "task_cancelled", "任务已取消。", {"previous_status": "running"})
     return storage.get_task(task_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.responses import Response
 
+from .api.artifacts import router as artifacts_router
 from .api.files import router as files_router
 from .api.models import router as models_router
 from .api.streaming import router as streaming_router
@@ -44,6 +45,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.include_router(tasks_router)
     app.include_router(files_router)
+    app.include_router(artifacts_router)
     app.include_router(streaming_router)
     app.include_router(models_router)
 

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -22,6 +22,16 @@ def get_model_info(model_id: str) -> dict | None:
     return _MODEL_INDEX.get(model_id)
 
 
+def is_model_available(model_id: str, settings: Settings) -> bool:
+    """Return whether *model_id* is registered and its provider key is configured."""
+    entry = get_model_info(model_id)
+    if entry is None:
+        return False
+    provider = cast(str, entry["provider"])
+    key_attr = _PROVIDER_KEY_ATTR.get(provider)
+    return bool(key_attr and getattr(settings, key_attr, None))
+
+
 def list_available_models(settings: Settings) -> list[dict]:
     """Return registry entries annotated with an ``available`` flag.
 

--- a/backend/app/runner/core.py
+++ b/backend/app/runner/core.py
@@ -138,12 +138,16 @@ class TaskRunner:
                         run_id=run_id,
                     )
 
-                self.storage.update_task_if_status(
+                self.storage.update_task_if_status_and_append_event(
                     task_id,
                     {"running"},
                     status="complete",
                     run_id=run_id,
                     append_message=append_message,
+                    event_type="task_completed",
+                    event_message="任务已完成。",
+                    event_payload={"previous_status": "running"},
+                    event_level="success",
                 )
 
                 # Emit a synthetic final_answer event so the frontend can
@@ -159,18 +163,43 @@ class TaskRunner:
                         level="success",
                     )
             except TimeoutError:
-                self.storage.update_task_if_status(
+                error_message = f"运行超时（{self.settings.agent_timeout_seconds}秒）"
+                self.storage.update_task_if_status_and_append_event(
                     task_id,
                     {"running"},
                     status="failed",
-                    error=f"运行超时（{self.settings.agent_timeout_seconds}秒）",
+                    error=error_message,
                     run_id=run_id,
+                    event_type="task_failed",
+                    event_message=error_message,
+                    event_payload={"error": error_message, "reason": "timeout"},
+                    event_level="error",
                 )
             except asyncio.CancelledError:
-                self.storage.update_task_if_status(task_id, {"running"}, status="cancelled", run_id=run_id)
+                self.storage.update_task_if_status_and_append_event(
+                    task_id,
+                    {"running"},
+                    status="cancelled",
+                    run_id=run_id,
+                    event_type="task_cancelled",
+                    event_message="任务已取消。",
+                    event_payload={"previous_status": "running"},
+                    event_level="warning",
+                )
                 raise
             except Exception as exc:
-                self.storage.update_task_if_status(task_id, {"running"}, status="failed", error=str(exc), run_id=run_id)
+                error_message = str(exc)
+                self.storage.update_task_if_status_and_append_event(
+                    task_id,
+                    {"running"},
+                    status="failed",
+                    error=error_message,
+                    run_id=run_id,
+                    event_type="task_failed",
+                    event_message=error_message,
+                    event_payload={"error": error_message},
+                    event_level="error",
+                )
                 raise
             finally:
                 self._active_runs.pop(task_id, None)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -101,3 +101,4 @@ class ModelOption(BaseModel):
     provider: str
     supports_files: bool
     supports_images: bool
+    available: bool = False

--- a/backend/tests/unit/api/test_artifacts.py
+++ b/backend/tests/unit/api/test_artifacts.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.config import Settings
+from app.main import create_app
+
+
+def _client(tmp_path):
+    settings = Settings(
+        task_root=tmp_path / "tasks",
+        workspace_root=tmp_path / "tasks",
+        deepseek_api_key="sk-test",
+    )
+    return TestClient(create_app(settings))
+
+
+def test_download_legacy_artifact(tmp_path):
+    client = _client(tmp_path)
+    created = client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"}).json()
+    task_id = created["task_id"]
+
+    storage = client.app.state.storage
+    storage.write_text(task_id, "artifacts/report.html", "<h1>报告</h1>")
+
+    response = client.get(f"/api/tasks/{task_id}/artifacts/report.html")
+
+    assert response.status_code == 200
+    assert response.text == "<h1>报告</h1>"
+    assert response.headers["content-type"].startswith("text/html")
+
+
+def test_download_run_scoped_artifact(tmp_path):
+    client = _client(tmp_path)
+    created = client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"}).json()
+    task_id = created["task_id"]
+
+    storage = client.app.state.storage
+    _, run_id = storage.start_run(
+        task_id,
+        message="生成报告",
+        model="deepseek:deepseek-chat",
+        expected_statuses={"idle"},
+    )
+    storage.write_run_text(task_id, run_id, "report.html", "<h1>本轮报告</h1>")
+    storage.update_task_if_status(task_id, {"running"}, status="complete", run_id=run_id)
+
+    response = client.get(f"/api/tasks/{task_id}/runs/{run_id}/artifacts/report.html")
+
+    assert response.status_code == 200
+    assert response.text == "<h1>本轮报告</h1>"
+
+
+def test_download_missing_artifact_returns_404(tmp_path):
+    client = _client(tmp_path)
+    created = client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"}).json()
+
+    response = client.get(f"/api/tasks/{created['task_id']}/artifacts/missing.html")
+
+    assert response.status_code == 404
+
+
+def test_download_rejects_invalid_artifact_name(tmp_path):
+    client = _client(tmp_path)
+    created = client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"}).json()
+
+    response = client.get(f"/api/tasks/{created['task_id']}/artifacts/%2e%2e")
+
+    assert response.status_code == 400
+

--- a/backend/tests/unit/api/test_models.py
+++ b/backend/tests/unit/api/test_models.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.config import Settings
+from app.main import create_app
+
+
+def test_get_models_preserves_available_flag(tmp_path):
+    settings = Settings(
+        task_root=tmp_path / "tasks",
+        workspace_root=tmp_path / "tasks",
+        deepseek_api_key="sk-test",
+    )
+    client = TestClient(create_app(settings))
+
+    response = client.get("/api/models")
+
+    assert response.status_code == 200
+    models = response.json()
+    deepseek = [model for model in models if model["provider"] == "deepseek"]
+    openai = [model for model in models if model["provider"] == "openai"]
+    assert deepseek
+    assert all(model["available"] is True for model in deepseek)
+    assert all(model["available"] is False for model in openai)
+

--- a/backend/tests/unit/api/test_tasks.py
+++ b/backend/tests/unit/api/test_tasks.py
@@ -12,6 +12,7 @@ def app_client(tmp_path):
     settings = Settings(
         task_root=tmp_path / "tasks",
         workspace_root=tmp_path / "tasks",
+        deepseek_api_key="sk-test",
     )
     app = create_app(settings)
     return TestClient(app)
@@ -45,6 +46,27 @@ class TestCreateTask:
         assert data["status"] == "idle"
         assert data["messages"] == []
 
+    def test_create_task_rejects_unknown_model(self, app_client):
+        response = app_client.post("/api/tasks", json={"model": "fake:model"})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "模型不在允许列表中"
+
+    def test_create_task_with_message_requires_configured_provider_key(self, tmp_path):
+        settings = Settings(
+            task_root=tmp_path / "tasks",
+            workspace_root=tmp_path / "tasks",
+        )
+        client = TestClient(create_app(settings))
+
+        response = client.post(
+            "/api/tasks",
+            json={"message": "hello", "model": "deepseek:deepseek-chat"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "模型服务未配置，请先在后端配置对应 API Key"
+
 
 class TestGetTask:
     def test_get_idle_task_returns_state(self, create_idle_task, app_client):
@@ -65,6 +87,13 @@ class TestGetTask:
         state = get_resp.json()
         assert state["status"] == "idle"
         assert state["messages"] == []
+
+    def test_get_task_can_omit_events_for_lightweight_refresh(self, create_idle_task, app_client):
+        created = create_idle_task()
+        response = app_client.get(f"/api/tasks/{created['task_id']}?include_events=false")
+
+        assert response.status_code == 200
+        assert response.json()["events"] == []
 
 
 class TestGetEvents:
@@ -134,6 +163,22 @@ class TestSendMessage:
         assert len(user_messages) == 1
         assert user_messages[0]["content"] == "test message content"
 
+    def test_send_message_requires_configured_provider_key(self, tmp_path):
+        settings = Settings(
+            task_root=tmp_path / "tasks",
+            workspace_root=tmp_path / "tasks",
+        )
+        client = TestClient(create_app(settings))
+        created = client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"}).json()
+
+        response = client.post(
+            f"/api/tasks/{created['task_id']}/messages",
+            json={"message": "hello", "model": "deepseek:deepseek-chat"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "模型服务未配置，请先在后端配置对应 API Key"
+
 
 class TestUploadFiles:
     def test_upload_to_idle_task_succeeds(self, create_idle_task, app_client):
@@ -150,6 +195,84 @@ class TestUploadFiles:
             files={"files": ("test.md", b"# test", "text/markdown")},
         )
         assert response.status_code == 404
+
+    def test_upload_duplicate_file_returns_409(self, create_idle_task, app_client):
+        created = create_idle_task()
+        task_id = created["task_id"]
+        first = app_client.post(
+            f"/api/tasks/{task_id}/files",
+            files={"files": ("test.md", b"# test", "text/markdown")},
+        )
+        assert first.status_code == 201
+
+        response = app_client.post(
+            f"/api/tasks/{task_id}/files",
+            files={"files": ("test.md", b"# again", "text/markdown")},
+        )
+
+        assert response.status_code == 409
+        assert "上传文件已存在" in response.json()["detail"]
+
+    def test_upload_unsupported_extension_returns_400(self, create_idle_task, app_client):
+        created = create_idle_task()
+
+        response = app_client.post(
+            f"/api/tasks/{created['task_id']}/files",
+            files={"files": ("notes.txt", b"hello", "text/plain")},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "仅支持上传 Markdown 或 JSON 文件"
+
+    def test_upload_invalid_json_returns_400_without_partial_file(self, create_idle_task, app_client):
+        created = create_idle_task()
+        task_id = created["task_id"]
+
+        response = app_client.post(
+            f"/api/tasks/{task_id}/files",
+            files={"files": ("data.json", b"{invalid", "application/json")},
+        )
+
+        assert response.status_code == 400
+        assert "内容不是合法 JSON" in response.json()["detail"]
+        assert app_client.app.state.storage.list_uploads(task_id) == []
+
+    def test_upload_over_file_count_limit_returns_413(self, tmp_path):
+        settings = Settings(
+            task_root=tmp_path / "tasks",
+            workspace_root=tmp_path / "tasks",
+            deepseek_api_key="sk-test",
+            max_upload_files=1,
+        )
+        client = TestClient(create_app(settings))
+        created = client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"}).json()
+
+        response = client.post(
+            f"/api/tasks/{created['task_id']}/files",
+            files=[
+                ("files", ("a.md", b"a", "text/markdown")),
+                ("files", ("b.md", b"b", "text/markdown")),
+            ],
+        )
+
+        assert response.status_code == 413
+
+    def test_upload_over_file_size_limit_returns_413(self, tmp_path):
+        settings = Settings(
+            task_root=tmp_path / "tasks",
+            workspace_root=tmp_path / "tasks",
+            deepseek_api_key="sk-test",
+            max_upload_file_bytes=4,
+        )
+        client = TestClient(create_app(settings))
+        created = client.post("/api/tasks", json={"model": "deepseek:deepseek-chat"}).json()
+
+        response = client.post(
+            f"/api/tasks/{created['task_id']}/files",
+            files={"files": ("big.md", b"12345", "text/markdown")},
+        )
+
+        assert response.status_code == 413
 
 
 class TestCancelTask:

--- a/backend/tests/unit/models/test_registry.py
+++ b/backend/tests/unit/models/test_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.config import Settings
 from app.models.registry import (
     get_model_info,
+    is_model_available,
     list_available_models,
     validate_model,
 )
@@ -63,3 +64,20 @@ class TestListAvailableModels:
             assert "label" in entry
             assert "provider" in entry
             assert "available" in entry
+
+
+class TestIsModelAvailable:
+    def test_unknown_model_is_not_available(self, test_settings):
+        assert is_model_available("fake:model", test_settings) is False
+
+    def test_registered_model_without_key_is_not_available(self, test_settings):
+        assert is_model_available("deepseek:deepseek-chat", test_settings) is False
+
+    def test_registered_model_with_key_is_available(self, tmp_path):
+        settings = Settings(
+            task_root=tmp_path / "tasks",
+            workspace_root=tmp_path / "tasks",
+            deepseek_api_key="sk-test",
+        )
+
+        assert is_model_available("deepseek:deepseek-chat", settings) is True

--- a/backend/tests/unit/runner/test_core.py
+++ b/backend/tests/unit/runner/test_core.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 
+import pytest
+from langchain_core.messages import AIMessage
+
 from app.runner.core import TaskRunner
+from app.storage import TaskStorage
 
 
 class TestTaskRunnerInit:
@@ -27,3 +32,112 @@ class TestTaskRunnerInit:
     def test_no_active_runs_after_init(self, test_settings):
         runner = TaskRunner(test_settings)
         assert runner._active_runs == {}
+
+
+async def _wait_for_runner(runner: TaskRunner, task_id: str) -> None:
+    for _ in range(50):
+        if not runner.is_running(task_id):
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("runner did not finish")
+
+
+class TestTaskRunnerTerminalEvents:
+    @pytest.mark.asyncio
+    async def test_successful_background_run_writes_task_completed_event(
+        self, test_settings, monkeypatch
+    ):
+        storage = TaskStorage(test_settings.task_root)
+        runner = TaskRunner(test_settings, storage)
+        state = storage.create_task(message=None, model="deepseek:deepseek-chat")
+        run_result = storage.start_run(
+            state.task_id,
+            message="hello",
+            model="deepseek:deepseek-chat",
+            expected_statuses={"idle"},
+        )
+        assert run_result is not None
+        _, run_id = run_result
+
+        async def fake_start(*args, **kwargs):
+            return [], {"messages": [AIMessage(content="done")]}
+
+        monkeypatch.setattr(runner, "start", fake_start)
+
+        runner.start_background(state.task_id, "hello", model="deepseek:deepseek-chat", run_id=run_id)
+        await _wait_for_runner(runner, state.task_id)
+
+        events = storage.read_events(state.task_id)
+        completed = [event for event in events if event.type == "task_completed"]
+        final_answers = [event for event in events if event.type == "final_answer"]
+
+        assert len(completed) == 1
+        assert completed[0].run_id == run_id
+        assert completed[0].level == "success"
+        assert len(final_answers) == 1
+        assert final_answers[0].run_id == run_id
+
+    @pytest.mark.asyncio
+    async def test_failed_background_run_writes_task_failed_event(
+        self, test_settings, monkeypatch
+    ):
+        storage = TaskStorage(test_settings.task_root)
+        runner = TaskRunner(test_settings, storage)
+        state = storage.create_task(message=None, model="deepseek:deepseek-chat")
+        run_result = storage.start_run(
+            state.task_id,
+            message="hello",
+            model="deepseek:deepseek-chat",
+            expected_statuses={"idle"},
+        )
+        assert run_result is not None
+        _, run_id = run_result
+
+        async def fake_start(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(runner, "start", fake_start)
+
+        runner.start_background(state.task_id, "hello", model="deepseek:deepseek-chat", run_id=run_id)
+        await _wait_for_runner(runner, state.task_id)
+
+        failed = [event for event in storage.read_events(state.task_id) if event.type == "task_failed"]
+
+        assert len(failed) == 1
+        assert failed[0].run_id == run_id
+        assert failed[0].payload["error"] == "boom"
+        assert storage.get_task(state.task_id).status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_background_run_writes_run_scoped_cancel_event(
+        self, test_settings, monkeypatch
+    ):
+        storage = TaskStorage(test_settings.task_root)
+        runner = TaskRunner(test_settings, storage)
+        state = storage.create_task(message=None, model="deepseek:deepseek-chat")
+        run_result = storage.start_run(
+            state.task_id,
+            message="hello",
+            model="deepseek:deepseek-chat",
+            expected_statuses={"idle"},
+        )
+        assert run_result is not None
+        _, run_id = run_result
+
+        async def fake_start(*args, **kwargs):
+            await asyncio.sleep(60)
+            return [], {}
+
+        monkeypatch.setattr(runner, "start", fake_start)
+
+        runner.start_background(state.task_id, "hello", model="deepseek:deepseek-chat", run_id=run_id)
+        await asyncio.sleep(0)
+        await runner.cancel(state.task_id)
+
+        cancelled = [
+            event for event in storage.read_events(state.task_id) if event.type == "task_cancelled"
+        ]
+
+        assert len(cancelled) == 1
+        assert cancelled[0].run_id == run_id
+        assert storage.get_task(state.task_id).status == "cancelled"

--- a/frontend/app/model-ui.ts
+++ b/frontend/app/model-ui.ts
@@ -12,6 +12,12 @@ type ModelPresentation = {
 };
 
 const MODEL_PRESENTATION: Record<string, ModelPresentation> = {
+  "deepseek:deepseek-chat": {
+    description: "通用对话与任务处理",
+  },
+  "deepseek:deepseek-reasoner": {
+    description: "多轮推理，回答复杂问题",
+  },
   "deepseek-reasoner": {
     label: "Deepseek",
     description: "多轮推理，回答复杂问题",

--- a/frontend/app/task-state.ts
+++ b/frontend/app/task-state.ts
@@ -181,9 +181,10 @@ export type ArtifactRequest = {
 export type ModelOption = {
   id: string;
   label: string;
+  available?: boolean;
 };
 
-export type MessageMode = "auto" | "chat" | "search" | "document_analysis" | "deep_agent";
+export type MessageMode = "auto" | "chat" | "analysis";
 
 export type MessageRequestPayload = {
   content: string;
@@ -996,6 +997,7 @@ export function normalizeModelOption(value: unknown): ModelOption | null {
   return {
     id,
     label: readString(record.label, id),
+    available: readOptionalBoolean(record.available),
   };
 }
 

--- a/frontend/e2e-playwright/README.md
+++ b/frontend/e2e-playwright/README.md
@@ -1,0 +1,18 @@
+# Browser E2E Evidence
+
+This directory contains reusable Playwright acceptance entrypoints plus local, timestamped evidence folders.
+
+- Commit reusable specs such as `test_runtime_contracts.spec.mjs`.
+- Store run-specific screenshots and downloaded artifacts under `e2e-YYYYMMDDHHMMSS/`.
+- Do not commit timestamped evidence folders; they are local acceptance proof referenced in delivery notes.
+- Keep screenshots free of customer documents, provider keys, access tokens, and private local paths.
+
+Run the runtime-contract acceptance test from `frontend/` after starting the backend and frontend:
+
+```bash
+MYAGENT_E2E_BASE_URL=http://127.0.0.1:3001 \
+MYAGENT_E2E_API_URL=http://127.0.0.1:8001 \
+MYAGENT_E2E_TASK_ROOT=/tmp/myagent-e2e/tasks \
+MYAGENT_E2E_EVIDENCE_DIR=./e2e-playwright/e2e-YYYYMMDDHHMMSS/runtime-contracts \
+npm run e2e:runtime-contracts
+```

--- a/frontend/e2e-playwright/test_runtime_contracts.spec.mjs
+++ b/frontend/e2e-playwright/test_runtime_contracts.spec.mjs
@@ -1,0 +1,218 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+const BASE_URL = process.env.MYAGENT_E2E_BASE_URL || "http://127.0.0.1:3001";
+const API_URL = process.env.MYAGENT_E2E_API_URL || "http://127.0.0.1:8001";
+const TASK_ROOT = process.env.MYAGENT_E2E_TASK_ROOT;
+const EVIDENCE_DIR = process.env.MYAGENT_E2E_EVIDENCE_DIR;
+
+function requirePath(value, name) {
+  if (!value) {
+    throw new Error(`${name} is required for runtime-contract E2E`);
+  }
+  return value;
+}
+
+function nowIso() {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeEvents(taskDir, taskId, runId, timestamp) {
+  const eventsDir = path.join(taskDir, "logs");
+  fs.mkdirSync(eventsDir, { recursive: true });
+  const events = [
+    {
+      id: randomUUID().replaceAll("-", ""),
+      session_id: taskId,
+      seq: 0,
+      type: "task_created",
+      message: "任务目录已创建。",
+      created_at: timestamp,
+      payload: { model: "deepseek:deepseek-chat" },
+      run_id: null,
+      level: null,
+      idempotency_key: null,
+    },
+    {
+      id: randomUUID().replaceAll("-", ""),
+      session_id: taskId,
+      seq: 1,
+      type: "task_completed",
+      message: "任务已完成。",
+      created_at: timestamp,
+      payload: { previous_status: "running" },
+      run_id: runId,
+      level: "success",
+      idempotency_key: null,
+    },
+    {
+      id: randomUUID().replaceAll("-", ""),
+      session_id: taskId,
+      seq: 2,
+      type: "final_answer",
+      message: "Final answer generated",
+      created_at: timestamp,
+      payload: { content: "E2E 报告已生成，可打开或下载。" },
+      run_id: runId,
+      level: "success",
+      idempotency_key: null,
+    },
+  ];
+  fs.writeFileSync(
+    path.join(eventsDir, "events.jsonl"),
+    `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
+    "utf8",
+  );
+}
+
+function seedCompletedArtifactTask(taskRoot, taskId) {
+  const timestamp = nowIso();
+  const runId = `run-e2e-${Date.now()}`;
+  const artifactName = "report.html";
+  const taskDir = path.join(taskRoot, taskId);
+  const artifactDir = path.join(taskDir, "artifacts", "runs", runId);
+  const statePath = path.join(taskDir, "state.json");
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+
+  fs.mkdirSync(artifactDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(artifactDir, artifactName),
+    [
+      "<!doctype html>",
+      "<html><head><meta charset=\"utf-8\"><title>E2E Report</title></head>",
+      "<body><h1>E2E 运行契约报告</h1><p>产物打开与下载链路可用。</p></body></html>",
+    ].join(""),
+    "utf8",
+  );
+
+  Object.assign(state, {
+    status: "complete",
+    model: "deepseek:deepseek-chat",
+    updated_at: timestamp,
+    active_run_id: null,
+    run_count: 1,
+    upload_count: 0,
+    error: null,
+    needs_input: null,
+    messages: [
+      {
+        role: "user",
+        content: "E2E 运行契约验收",
+        created_at: timestamp,
+        run_id: runId,
+        level: null,
+      },
+      {
+        role: "assistant",
+        content: "E2E 报告已生成，可打开或下载。",
+        created_at: timestamp,
+        run_id: runId,
+        level: null,
+      },
+    ],
+    runs: [
+      {
+        id: runId,
+        status: "complete",
+        message: "E2E 运行契约验收",
+        model: "deepseek:deepseek-chat",
+        started_at: timestamp,
+        completed_at: timestamp,
+        error: null,
+        needs_input: null,
+        artifact_base_path: `artifacts/runs/${runId}`,
+        artifact_names: [artifactName],
+      },
+    ],
+    events: [],
+    artifacts: [],
+  });
+
+  writeJson(statePath, state);
+  writeEvents(taskDir, taskId, runId, timestamp);
+  return { artifactName, runId };
+}
+
+test.use({ acceptDownloads: true, baseURL: BASE_URL });
+
+test("runtime task contracts expose artifacts and upload errors in the browser", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(90_000);
+
+  const taskRoot = requirePath(TASK_ROOT, "MYAGENT_E2E_TASK_ROOT");
+  const evidenceDir = requirePath(EVIDENCE_DIR, "MYAGENT_E2E_EVIDENCE_DIR");
+  fs.mkdirSync(evidenceDir, { recursive: true });
+
+  const createdResponse = await request.post(`${API_URL}/api/tasks`, {
+    data: { model: "deepseek:deepseek-chat" },
+  });
+  expect(createdResponse.status()).toBe(201);
+  const createdTask = await createdResponse.json();
+  const taskId = createdTask.task_id;
+  const { artifactName, runId } = seedCompletedArtifactTask(taskRoot, taskId);
+
+  const lightweightResponse = await request.get(`${API_URL}/api/tasks/${taskId}?include_events=false`);
+  expect(lightweightResponse.ok()).toBeTruthy();
+  const lightweightTask = await lightweightResponse.json();
+  expect(lightweightTask.events).toEqual([]);
+  expect(lightweightTask.artifacts.some((artifact) => artifact.name === artifactName)).toBeTruthy();
+
+  const modelsResponse = await request.get(`${API_URL}/api/models`);
+  expect(modelsResponse.ok()).toBeTruthy();
+  const models = await modelsResponse.json();
+  expect(models.some((model) => typeof model.available === "boolean")).toBeTruthy();
+
+  await page.goto("/");
+  await expect(page.getByRole("button", { name: /新建会话/ })).toBeVisible();
+  await page.screenshot({ fullPage: true, path: path.join(evidenceDir, "01-history-loaded.png") });
+
+  await page.getByRole("button", { name: /E2E/ }).first().click();
+  await expect(page.getByText(artifactName)).toBeVisible();
+  await expect(page.getByText("AI回复")).toBeVisible();
+  await expect(page.getByText("已完成").first()).toBeVisible();
+  await page.screenshot({ fullPage: true, path: path.join(evidenceDir, "02-artifact-card.png") });
+
+  const popupPromise = page.waitForEvent("popup");
+  await page.getByRole("button", { name: "打开" }).click();
+  const popup = await popupPromise;
+  await popup.waitForLoadState("domcontentloaded");
+  await expect(popup.locator("body")).toContainText("E2E 运行契约报告");
+  await popup.screenshot({ fullPage: true, path: path.join(evidenceDir, "03-opened-report.png") });
+  await popup.close();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "下载" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe(artifactName);
+  await download.saveAs(path.join(evidenceDir, "downloaded-report.html"));
+  await page.screenshot({ fullPage: true, path: path.join(evidenceDir, "04-download-finished.png") });
+
+  await page.getByRole("button", { name: "新建会话" }).click();
+  const invalidJsonPath = path.join(evidenceDir, "invalid-upload.json");
+  fs.writeFileSync(invalidJsonPath, "{ invalid json", "utf8");
+  await page.locator("#document-files").setInputFiles(invalidJsonPath);
+  await expect(page.getByText("invalid-upload.json")).toBeVisible();
+  await page.screenshot({ fullPage: true, path: path.join(evidenceDir, "05-invalid-json-selected.png") });
+
+  await page.getByRole("button", { name: "发送" }).click();
+  await expect(page.getByText(/HTTP 400|内容不是合法 JSON|JSON 文件/)).toBeVisible();
+  await page.screenshot({ fullPage: true, path: path.join(evidenceDir, "06-invalid-json-error.png") });
+
+  writeJson(path.join(evidenceDir, "assertions.json"), {
+    artifactName,
+    downloadedArtifact: "downloaded-report.html",
+    includeEventsFalseReturnedEmptyEvents: true,
+    modelsExposeAvailable: true,
+    runId,
+    taskId,
+  });
+});

--- a/frontend/hooks/use-task-workspace.ts
+++ b/frontend/hooks/use-task-workspace.ts
@@ -10,9 +10,11 @@ import {
   type TaskStatus,
   type TaskSummary,
   formatNeedsInput,
+  isRecord,
   isTaskActive,
   mergeExecutionLogs,
   normalizeEventRecords,
+  readString,
 } from "../app/task-state";
 import {
   buildModelDisplayOptions,
@@ -43,12 +45,24 @@ import {
 
 const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   {
-    id: "deepseek-reasoner",
-    label: "Deepseek",
+    id: "deepseek:deepseek-chat",
+    label: "DeepSeek Chat",
   },
 ];
 
 const DEFAULT_FILE_PROMPT = "请分析已上传的 Markdown 或 JSON 文件是否存在串标围标嫌疑。";
+export const MAX_SSE_RETRIES = 5;
+
+export function calculateSseRetryDelay(retryCount: number) {
+  return Math.min(3000 * Math.pow(2, retryCount), 30000);
+}
+
+export function getSseErrorDetail(payload: unknown) {
+  if (!isRecord(payload) || payload.type !== "error") {
+    return "";
+  }
+  return readString(payload.detail, "流传输异常，请刷新页面。");
+}
 
 export function useTaskWorkspace() {
   const [taskId, setTaskId] = useState<string>("");
@@ -214,7 +228,6 @@ export function useTaskWorkspace() {
 
     function startSSE() {
       if (disposed) return;
-      retryCount = 0;
 
       es = createTaskEventSource(
         taskId,
@@ -222,6 +235,14 @@ export function useTaskWorkspace() {
           if (disposed) return;
           try {
             const payload = JSON.parse(event.data);
+            retryCount = 0;
+            const sseErrorDetail = getSseErrorDetail(payload);
+            if (sseErrorDetail) {
+              setErrorLevel("error");
+              setError(sseErrorDetail);
+              void refreshTaskSummary();
+              return;
+            }
             const recognizedTypes = [
               "log",
               "tool_call",
@@ -229,6 +250,9 @@ export function useTaskWorkspace() {
               "assistant_answer_delta",
               "status_update",
               "final_answer",
+              "task_completed",
+              "task_failed",
+              "task_cancelled",
             ];
             if (
               payload &&
@@ -254,7 +278,12 @@ export function useTaskWorkspace() {
           es = null;
           void Promise.all([refreshTaskSummary(), refreshTaskEvents()]).catch(() => {});
           if (!disposed) {
-            const backoffMs = Math.min(3000 * Math.pow(2, retryCount), 30000);
+            if (retryCount >= MAX_SSE_RETRIES) {
+              setErrorLevel("error");
+              setError("流连接多次重试失败，请刷新页面或稍后重试。");
+              return;
+            }
+            const backoffMs = calculateSseRetryDelay(retryCount);
             retryCount++;
             retryTimeoutId = window.setTimeout(() => {
               retryTimeoutId = null;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,13 +8,14 @@
       "name": "myagent-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "next": "^15.3.0",
+        "next": "^15.5.18",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/node": "^22.13.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -1237,9 +1238,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
-      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1253,9 +1254,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
-      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1269,9 +1270,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
-      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -1285,9 +1286,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
-      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -1304,9 +1305,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
-      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -1323,9 +1324,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
-      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -1342,9 +1343,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
-      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -1361,9 +1362,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
-      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -1377,9 +1378,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
-      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -1438,6 +1439,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -5691,12 +5708,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
-      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.15",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -5709,14 +5726,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.15",
-        "@next/swc-darwin-x64": "15.5.15",
-        "@next/swc-linux-arm64-gnu": "15.5.15",
-        "@next/swc-linux-arm64-musl": "15.5.15",
-        "@next/swc-linux-x64-gnu": "15.5.15",
-        "@next/swc-linux-x64-musl": "15.5.15",
-        "@next/swc-win32-arm64-msvc": "15.5.15",
-        "@next/swc-win32-x64-msvc": "15.5.15",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -6044,6 +6061,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,10 +8,11 @@
     "start": "next start -p 3001",
     "typecheck": "next typegen && tsc --noEmit",
     "test": "node --test --import tsx tests/*/test_*.test.ts",
+    "e2e:runtime-contracts": "playwright test e2e-playwright/test_runtime_contracts.spec.mjs --reporter=line",
     "lint": "eslint . --max-warnings=0"
   },
   "dependencies": {
-    "next": "^15.3.0",
+    "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
@@ -21,6 +22,7 @@
     "postcss": "^8.5.10"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22.13.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/frontend/tests/model/test_model_ui.test.ts
+++ b/frontend/tests/model/test_model_ui.test.ts
@@ -8,7 +8,7 @@ import {
 
 test("buildModelDisplayOptions adds compact model descriptions for the picker", () => {
   const options = buildModelDisplayOptions([
-    { id: "deepseek-reasoner", label: "DeepSeek Reasoner" },
+    { id: "deepseek:deepseek-reasoner", label: "DeepSeek Reasoner" },
     { id: "k26-agent-cluster", label: "K2.6 Agent 集群" },
     { id: "k26-quick", label: "K2.6 快速" },
   ]);
@@ -23,7 +23,7 @@ test("buildModelDisplayOptions adds compact model descriptions for the picker", 
       {
         badge: undefined,
         description: "多轮推理，回答复杂问题",
-        label: "Deepseek",
+        label: "DeepSeek Reasoner",
       },
       {
         badge: "测试",

--- a/frontend/tests/state/test_task_state.test.ts
+++ b/frontend/tests/state/test_task_state.test.ts
@@ -13,6 +13,7 @@ import {
   isTaskActive,
   mergeExecutionLogs,
   mergeTaskState,
+  normalizeModelOption,
   normalizeTaskSummaries,
   normalizeTaskState,
   resolveApiBaseUrl,
@@ -118,24 +119,39 @@ test("buildArtifactRequest builds run-scoped artifact URLs with the access token
 });
 
 test("buildMessageRequestPayload sends the default mode without a file-scope toggle", () => {
-  assert.deepEqual(buildMessageRequestPayload("请分析这些文件", "deepseek-reasoner"), {
+  assert.deepEqual(buildMessageRequestPayload("请分析这些文件", "deepseek:deepseek-chat"), {
     content: "请分析这些文件",
     message: "请分析这些文件",
-    model: "deepseek-reasoner",
+    model: "deepseek:deepseek-chat",
     mode: "auto",
   });
 });
 
 test("buildMessageRequestPayload allows explicit mode overrides", () => {
   assert.deepEqual(
-    buildMessageRequestPayload("继续分析这些文件", "deepseek-reasoner", {
-      mode: "deep_agent",
+    buildMessageRequestPayload("继续分析这些文件", "deepseek:deepseek-chat", {
+      mode: "analysis",
     }),
     {
       content: "继续分析这些文件",
       message: "继续分析这些文件",
-      model: "deepseek-reasoner",
-      mode: "deep_agent",
+      model: "deepseek:deepseek-chat",
+      mode: "analysis",
+    },
+  );
+});
+
+test("normalizeModelOption preserves backend availability metadata", () => {
+  assert.deepEqual(
+    normalizeModelOption({
+      id: "deepseek:deepseek-chat",
+      label: "DeepSeek Chat",
+      available: false,
+    }),
+    {
+      id: "deepseek:deepseek-chat",
+      label: "DeepSeek Chat",
+      available: false,
     },
   );
 });

--- a/frontend/tests/workspace/test_task_workspace.test.ts
+++ b/frontend/tests/workspace/test_task_workspace.test.ts
@@ -6,4 +6,23 @@ void describe("use-task-workspace exports", () => {
     const mod = await import("../../hooks/use-task-workspace");
     assert.strictEqual(typeof mod.useTaskWorkspace, "function");
   });
+
+  void it("should expose bounded SSE retry helpers", async () => {
+    const mod = await import("../../hooks/use-task-workspace");
+
+    assert.strictEqual(mod.MAX_SSE_RETRIES, 5);
+    assert.strictEqual(mod.calculateSseRetryDelay(0), 3000);
+    assert.strictEqual(mod.calculateSseRetryDelay(1), 6000);
+    assert.strictEqual(mod.calculateSseRetryDelay(4), 30000);
+  });
+
+  void it("should extract backend SSE error details", async () => {
+    const mod = await import("../../hooks/use-task-workspace");
+
+    assert.strictEqual(
+      mod.getSseErrorDetail({ type: "error", detail: "流传输异常，请刷新页面。" }),
+      "流传输异常，请刷新页面。",
+    );
+    assert.strictEqual(mod.getSseErrorDetail({ type: "done" }), "");
+  });
 });


### PR DESCRIPTION
## 修复范围

Closes #84
Closes #85
Closes #86
Closes #87
Closes #88
Closes #90

#89 保持开放，作为低优先级 storage 事件追加性能优化单独处理，避免混入本轮正确性与安全依赖修复。

## 主要变更

- 补齐任务产物下载 API，支持 legacy/latest 与 run-scoped artifact 下载，并通过 storage 解析防止越界访问。
- 上传 API 将重复文件、大小/数量限制、非法扩展名、非法 JSON 分别映射为明确 4xx，不再泄漏为 500。
- 模型列表保留 `available`，任务创建/发送消息在启动 run 前校验模型注册表和 provider key；前端兜底模型改为 provider-prefixed ID。
- runner 在 complete/failed/timeout/cancel 路径写入 run-scoped 终态事件，取消接口不再追加重复的无 run_id 事件。
- 前端支持 `include_events=false` 轻量刷新、SSE error payload 展示和有上限的指数退避重连。
- 升级 Next.js 到 15.5.18，并新增可复用 Playwright E2E 入口与截图目录忽略规则。
- 更新 `asset/deepagents_platform_knowledge_pack.md`，沉淀本轮运行契约边界。

## 验证

- `cd backend && uv run pytest`：126 passed
- `cd backend && uv run ruff check .`：通过
- `cd backend && uv run mypy app tests`：通过
- `cd frontend && npm test`：107 passed
- `cd frontend && npm run lint`：通过，`--max-warnings=0` 无 warning
- `cd frontend && npm run typecheck`：通过
- `cd frontend && npm run build`：通过
- `cd frontend && npm audit`：0 vulnerabilities
- `git diff --check`：通过

## 浏览器 E2E

本地启动实际服务：

- 后端：`http://127.0.0.1:8011`
- 前端：`http://127.0.0.1:3011`
- 独立任务根：`/tmp/myagent-agents-audit-e2e-20260512082927/tasks`

执行：

```bash
env -u NO_COLOR MYAGENT_E2E_BASE_URL=http://127.0.0.1:3011 MYAGENT_E2E_API_URL=http://127.0.0.1:8011 MYAGENT_E2E_TASK_ROOT=/tmp/myagent-agents-audit-e2e-20260512082927/tasks MYAGENT_E2E_EVIDENCE_DIR=/mnt/d/AgentProject/MyAgent-agents-audit-fix-84-90/frontend/e2e-playwright/e2e-20260512082927/runtime-contracts npm run e2e:runtime-contracts
```

结果：1 passed。

截图证据保存在本地，不提交到 git：

- `/mnt/d/AgentProject/MyAgent-agents-audit-fix-84-90/frontend/e2e-playwright/e2e-20260512082927/runtime-contracts/01-history-loaded.png`
- `/mnt/d/AgentProject/MyAgent-agents-audit-fix-84-90/frontend/e2e-playwright/e2e-20260512082927/runtime-contracts/02-artifact-card.png`
- `/mnt/d/AgentProject/MyAgent-agents-audit-fix-84-90/frontend/e2e-playwright/e2e-20260512082927/runtime-contracts/03-opened-report.png`
- `/mnt/d/AgentProject/MyAgent-agents-audit-fix-84-90/frontend/e2e-playwright/e2e-20260512082927/runtime-contracts/04-download-finished.png`
- `/mnt/d/AgentProject/MyAgent-agents-audit-fix-84-90/frontend/e2e-playwright/e2e-20260512082927/runtime-contracts/05-invalid-json-selected.png`
- `/mnt/d/AgentProject/MyAgent-agents-audit-fix-84-90/frontend/e2e-playwright/e2e-20260512082927/runtime-contracts/06-invalid-json-error.png`

## 审计说明

本轮遵循 `$agents-audit` 本地审计协议完成 Issue 创建、本地修复、测试和浏览器 E2E。该技能协议禁止执行远端 CI/CD 等待类动作；仓库规则要求 PR 动作后等待远端 checks，二者存在流程冲突，因此本 PR 不在正文中声明远端 checks 已完成。
