### PR TITLE
修复(storage): 登记所有 run-scoped 产物

### DIFF
--- a/asset/deepagents_platform_knowledge_pack.md
+++ b/asset/deepagents_platform_knowledge_pack.md
@@ -69,6 +69,7 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - Missing provider API keys make affected models unavailable at `/api/models` and must block run-starting requests before background scheduling. This avoids creating task runs that are guaranteed to fail only after storage state changes. The browser UI should surface unavailable models as disabled rather than allowing users to create an idle task or upload files before the send fails.
 - History rename/delete are real task API operations, not frontend-only state. Rename stores a bounded custom task title; delete must reject running tasks to avoid orphaning an active in-process runner.
 - Artifact names are normalized file names only, not paths. Artifact download routes must resolve through `TaskStorage.resolve_artifact()` or `TaskStorage.resolve_run_artifact()` so path traversal and cross-run access stay blocked.
+- Run-scoped artifact registration uses `runs.artifact_names` as the authoritative index for frontend rendering and `resolve_run_artifact()` downloads. `write_run_text()` / `write_run_json()` must record every valid run-scoped artifact name, while `RUN_ARTIFACT_NAMES` only controls which standard artifacts are additionally mirrored to the legacy top-level `artifacts/` path.
 - Frontend artifact URL validation is an additional client boundary, not a replacement for backend path checks. Backend routes must keep resolving through storage, and frontend allowlists must continue to reject any URL that is not on the trusted API origin and artifact route shape.
 - `SKILL.md` files without valid YAML frontmatter are silently skipped during discovery.
 - `next typegen` loads `next.config.mjs` with the production build phase; keep any required config inputs available before running frontend type checks in CI.
@@ -82,6 +83,7 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - **SSE frontend backoff**: Browser-side SSE reconnect must be capped and use exponential backoff. Any backend SSE payload shaped as `{type: "error", detail: "..."}` is user-visible and should stop normal event processing for that message, then refresh task state defensively.
 - **Run-scoped terminal events**: Do not append terminal events from API endpoints after calling the runner. The runner owns terminal status plus terminal event writes so the `run_id` stays consistent and duplicate unscoped events are not produced.
 - **Artifact route drift**: Frontend artifact cards depend on `ArtifactRecord.url` pointing to real backend routes. Adding new artifact storage locations requires updating both the URL generator and the corresponding FastAPI download route.
+- **Run artifact index drift**: Do not make artifact registration depend on the legacy standard-report whitelist. If a run artifact is written but missing from `runs.artifact_names`, the file can exist on disk while the task state hides it and the run-scoped download route returns 404.
 - **Artifact URL token leak**: Do not pass backend-provided artifact URLs directly to `fetch`. `buildArtifactRequest()` owns allowlist validation and is the only place that may attach `X-MyAgent-Token` for artifact downloads.
 - **HTML artifact preview XSS**: Do not navigate an opened window to an artifact blob. HTML reports must render through a sandboxed iframe without `allow-scripts` so generated scripts cannot run in the app origin.
 - **Upload exception leakage**: Storage upload validation exceptions should be translated by the API layer. A malformed user upload is a 4xx client error, never an unhandled 500.
@@ -215,6 +217,7 @@ If the task includes pushing a branch, opening/updating a PR, or merging a PR, a
 - Model format mismatch if frontend sends old-style `deepseek-reasoner` instead of `deepseek:deepseek-chat`.
 - Model availability regression if `/api/models` stops exposing `available` or task/message endpoints schedule runs for unavailable providers.
 - Artifact download regression if `ArtifactRecord.url` no longer matches FastAPI routes or run-scoped artifacts fall back to the latest legacy artifact.
+- Run artifact visibility regression if `write_run_text()` or `write_run_json()` stops recording non-standard artifact names in `runs.artifact_names`.
 - Artifact security regression if external artifact URLs, same-origin non-artifact URLs, or wrong-task artifact URLs receive `X-MyAgent-Token`.
 - HTML preview regression if the artifact popup returns to `location.replace(blob:)` or grants iframe `allow-scripts`.
 - Upload API regression if duplicate names, limits, unsupported extensions, or invalid JSON again surface as 500 responses.

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -961,12 +961,12 @@ class PostgresTaskStorage:
         path.write_text(text, encoding="utf-8")
         if name in RUN_ARTIFACT_NAMES:
             self.write_text(task_id, f"artifacts/{name}", text)
-            self.record_run_artifact(
-                task_id,
-                run_id,
-                name,
-                artifact_ref=self._artifact_ref_payload(task_id, run_id, name, path),
-            )
+        self.record_run_artifact(
+            task_id,
+            run_id,
+            name,
+            artifact_ref=self._artifact_ref_payload(task_id, run_id, name, path),
+        )
         return path
 
     def run_artifact_dir(self, task_id: str, run_id: str) -> Path:

--- a/backend/tests/unit/storage/test_storage.py
+++ b/backend/tests/unit/storage/test_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.storage import PostgresTaskStorage
 from tests.fakes import InMemoryTaskStorage
 
 
@@ -98,3 +99,65 @@ class TestTaskStorageHistoryActions:
             pass
         else:
             raise AssertionError("Expected deleted task to be missing")
+
+
+class TestPostgresTaskStorageRunArtifacts:
+    def test_write_run_text_records_custom_run_artifact_without_database(self, tmp_path, monkeypatch):
+        storage = PostgresTaskStorage(tmp_path / "sessions", "postgresql://unused")
+        task_id = "task-1"
+        run_id = "run-test-001"
+        recorded: list[tuple[str, str, str, dict | None]] = []
+
+        def record_run_artifact(task_id_arg, run_id_arg, artifact_name_arg, *, artifact_ref=None):
+            recorded.append((task_id_arg, run_id_arg, artifact_name_arg, artifact_ref))
+
+        monkeypatch.setattr(storage, "record_run_artifact", record_run_artifact)
+
+        path = storage.write_run_text(task_id, run_id, "analysis-extra.json", '{"ok": true}')
+
+        assert path == (
+            tmp_path
+            / "sessions"
+            / task_id
+            / "artifacts"
+            / "runs"
+            / run_id
+            / "analysis-extra.json"
+        ).resolve()
+        assert path.read_text(encoding="utf-8") == '{"ok": true}'
+        assert len(recorded) == 1
+        recorded_task_id, recorded_run_id, recorded_name, artifact_ref = recorded[0]
+        assert recorded_task_id == task_id
+        assert recorded_run_id == run_id
+        assert recorded_name == "analysis-extra.json"
+        assert artifact_ref is not None
+        assert artifact_ref["id"] == "artifact:task-1:run-test-001:analysis-extra.json"
+        assert artifact_ref["name"] == "analysis-extra.json"
+        assert artifact_ref["type"] == "json"
+        assert artifact_ref["uri"] == (
+            "myagent://sessions/task-1/runs/run-test-001/artifacts/analysis-extra.json"
+        )
+        assert artifact_ref["run_id"] == run_id
+        assert artifact_ref["size_bytes"] == 12
+        assert artifact_ref["digest"] == (
+            "sha256:6bc0da1f42f96fc37b8bd7ed20ba57606d2a0da5cda2b135c7854fbdc985b8a3"
+        )
+        assert artifact_ref["resource_ref"]["kind"] == "artifact"
+        assert artifact_ref["resource_ref"]["name"] == "analysis-extra.json"
+
+    def test_write_run_text_keeps_top_level_mirror_for_fixed_artifacts(self, tmp_path, monkeypatch):
+        storage = PostgresTaskStorage(tmp_path / "sessions", "postgresql://unused")
+        task_id = "task-1"
+        run_id = "run-test-001"
+        recorded: list[str] = []
+
+        def record_run_artifact(_task_id, _run_id, artifact_name, *, artifact_ref=None):
+            recorded.append(artifact_name)
+
+        monkeypatch.setattr(storage, "record_run_artifact", record_run_artifact)
+
+        storage.write_run_text(task_id, run_id, "report.html", "<h1>报告</h1>")
+
+        mirrored = tmp_path / "sessions" / task_id / "artifacts" / "report.html"
+        assert mirrored.read_text(encoding="utf-8") == "<h1>报告</h1>"
+        assert recorded == ["report.html"]


### PR DESCRIPTION
## 变更

修复 Postgres 任务存储中 run-scoped 产物登记不完整的问题：`write_run_text()` / `write_run_json()` 现在会把所有合法运行产物写入 `runs.artifact_names`，不再只登记 `RUN_ARTIFACT_NAMES` 白名单内的标准报告产物。

标准产物仍保持原行为：继续额外镜像到 legacy 顶层 `artifacts/` 路径，兼容现有打开/下载链路。

## 影响文件

- `backend/app/storage.py`
- `backend/tests/unit/storage/test_storage.py`
- `asset/deepagents_platform_knowledge_pack.md`

## 本地验证

- [x] `cd backend && uv run pytest tests/unit/storage/test_storage.py tests/unit/api/test_artifacts.py` 通过：17 passed
- [x] `cd backend && uv run pytest` 通过：156 passed，3 skipped
- [x] `cd backend && uv run ruff check .` 通过
- [x] `cd backend && uv run mypy app tests` 通过
- [x] `cd frontend && npm run typecheck` 通过
- [x] `cd frontend && npm test` 通过：117 passed
- [x] `cd frontend && npm run lint` 通过，`--max-warnings=0`
- [x] `cd frontend && npm run build` 通过
- [x] `git diff --check` 通过

## 浏览器端 E2E 与截图

真实启动后端 `http://127.0.0.1:8012`、前端 `http://127.0.0.1:3012`，使用 Postgres-backed storage 和临时 task root 完成验收。

- [x] 现有 runtime-contract Playwright 场景通过：`logs/raw/fix-102-e2e-runtime-contracts.log`
- [x] Issue #102 专项 Playwright 场景通过：`logs/raw/fix-102-e2e-custom-run-artifact-3012.log`
- [x] 审计截图证据：`audits/agents-audit-20260512-2150/e2e-playwright/issue-102/runtime-contracts/*.png`
- [x] 审计截图证据：`audits/agents-audit-20260512-2150/e2e-playwright/issue-102/custom-run-artifact/*.png`
- [x] 仓库约定本地截图副本：`frontend/e2e-playwright/e2e-202605122150/issue-102/`

专项 E2E 验证 `analysis-extra.json` 已出现在任务状态、浏览器产物卡片中，并可通过 run-scoped 下载路由下载。

Closes #102

备注：本 agents-audit 流程按技能规则不等待远端检查；本地全量验证和浏览器 E2E 截图验收通过后会尝试普通合并。
