### PR TITLE
修复(contract): 收敛平台配置与文档契约漂移

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 
 - 后端行为变化至少补或更新 API、任务生命周期、存储、权限、模型路由或分析服务测试。
 - 前端行为变化至少补或更新表单、状态转换器、URL 映射、产物请求或注册表测试。
+- 上传格式属于跨后端校验、前端提示、E2E、README 和知识包共享的公开契约；新增、删除或重命名受支持扩展名时，必须同步后端允许列表、前端文案/测试、`README.md`、`backend/README.md`、`frontend/README.md` 和相关 `asset/` 知识包，不能只改其中一处。
 - 测试替身不能弱化生产公开契约；`backend/tests/fakes.py` 中的 `InMemoryTaskStorage` 必须与生产 `PostgresTaskStorage` 的任务状态、run artifact、latest/legacy 产物解析、事件游标和上传资源边界保持一致，新增公开存储契约时必须同步 fake 和生产测试。
 - 本地或远程 CI 中任何会导致非零退出码的 warning 都按失败处理，不能以“只是告警”为由交付；当前前端 lint 明确使用 `eslint . --max-warnings=0`，因此 ESLint warning 与 error 一样会阻塞 CI。
 - 新增、重构或修复浏览器关键流程时，优先用 Chrome DevTools MCP 打开本地页面做探索性检查：确认页面路径、登录或任务流程、控制台错误、关键 network 请求/响应、截图和必要的性能信号；探路结果只用于理解和定位，不算可交付验收。
@@ -102,8 +103,8 @@
 
 ### 需求修改后的知识回写路由
 
-- 改后端任务 API、状态机、任务 runner、取消/中断、事件日志、产物下载、本地存储、前端任务创建、文件上传、消息提交、状态轮询、日志合并、产物 URL、模型提供方、环境变量、访问令牌、CORS、本地优先安全边界、上传/JSON 限制或测试布局：优先沉淀到 `asset/deepagents_platform_knowledge_pack.md`。
-- 改 Markdown/JSON 招投标文档分类、围串标分析类别、sub-agent 分派、证据归一化、报告生成：默认先更新 `asset/deepagents_platform_knowledge_pack.md` 中的相关稳定边界；若形成独立长期主题，再新增或更新 `asset/bid_analysis_workflow_knowledge_pack.md`。
+- 改后端任务 API、状态机、任务 runner、取消/中断、事件日志、产物下载、本地存储、前端任务创建、文件上传、消息提交、状态轮询、日志合并、产物 URL、模型提供方、环境变量、访问令牌、CORS、本地优先安全边界、上传格式/JSON 限制或测试布局：优先沉淀到 `asset/deepagents_platform_knowledge_pack.md`。
+- 改招投标资源分类、围串标分析类别、sub-agent 分派、证据归一化、报告生成：默认先更新 `asset/deepagents_platform_knowledge_pack.md` 中的相关稳定边界；若形成独立长期主题，再新增或更新 `asset/bid_analysis_workflow_knowledge_pack.md`。
 - 改本地启动脚本、WSL 端口清理或开发终端启动方式：通常只更新 `README.md` 和本文件的本地开发建议；只有脚本演进为跨需求复用的稳定子系统时，才单独新增知识包。
 - 上述文件名是建议路由；若已有更合适的知识包，以实际主题边界为准。
 - 若新规则会影响未来多数需求，再把它从知识包提升写回 `AGENTS.md`。

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # MyAgent
 
-MyAgent 是一个本地优先的 AI 智能体工作区，用于基于 Markdown 的招投标文档分析。项目由 FastAPI 后端和 Next.js 前端组成：后端负责管理任务、运行分析 worker、持久化证据并生成报告；前端负责文件上传、任务消息、用户友好的任务直播日志、AI 回复和产物查看。
+MyAgent 是一个本地优先的 AI 智能体工作区，用于上传 Markdown、JSON、TXT、Word 和 Excel 资源并执行招投标文档分析。项目由 FastAPI 后端和 Next.js 前端组成：后端负责管理任务、运行分析 worker、持久化证据并生成报告；前端负责文件上传、任务消息、用户友好的任务直播日志、AI 回复和产物查看。
 
 当前 V1 工作流聚焦于围标、串标类文档检查：
 
 1. 在本地启动后端和前端。
-2. 上传 Markdown 或 JSON 格式的招标、投标文档。
+2. 上传 Markdown、JSON、TXT、DOCX、XLSX 或 XLSM 格式的招标、投标文档。
 3. 发送类似 `帮我检查是否有串标围标嫌疑` 的任务消息。
 4. 后端创建任务计划，运行分类 sub-agent，保存证据和结构化事件，并写入报告产物。
 5. 任务完成后，在前端打开 `report.html` 查看结果。
@@ -276,12 +276,12 @@ uv run uvicorn app.main:app --host 127.0.0.1 --port 8001
 ## 使用流程
 
 1. 在前端创建或复用一个任务。
-2. 上传文件名为 `.md` 或 `.json` 的文档文件。
+2. 上传文件名为 `.md`、`.json`、`.txt`、`.docx`、`.xlsx` 或 `.xlsm` 的文档文件。
 3. 发送描述所需分析的用户消息。
 4. 查看任务直播中的工具调用、结果摘要、回答生成状态和产物创建过程。
 5. 任务完成后打开生成的产物，尤其是 `report.html`。
 
-如果没有上传文件，且消息看起来不像招投标文档分析请求，后端支持简单聊天。文档分析请求必须上传 Markdown 或 JSON 文件。
+如果没有上传文件，且消息看起来不像招投标文档分析请求，后端支持简单聊天。文档分析请求必须上传 Markdown、JSON、TXT、DOCX、XLSX 或 XLSM 文件。
 
 ## API 概览
 
@@ -293,7 +293,7 @@ uv run uvicorn app.main:app --host 127.0.0.1 --port 8001
 - `PATCH /api/tasks/{task_id}` 重命名历史会话标题。
 - `DELETE /api/tasks/{task_id}` 删除非运行中的历史会话及其本地任务文件。
 - `GET /api/tasks/{task_id}/events` 读取增量事件记录。
-- `POST /api/tasks/{task_id}/files` 上传 Markdown 或 JSON 文件。
+- `POST /api/tasks/{task_id}/files` 上传 Markdown、JSON、TXT、DOCX、XLSX 或 XLSM 文件。
 - `POST /api/tasks/{task_id}/messages` 为任务启动或恢复工作。
 - `POST /api/tasks/{task_id}/cancel` 请求取消任务。
 - `GET /api/tasks/{task_id}/artifacts/{artifact_name}` 下载产物。
@@ -342,5 +342,5 @@ git diff --check
 
 - `403 任务 API 默认只允许本机访问。`：当前 README 只覆盖本机部署；请确认你访问的是 `http://localhost:3001` 或 `http://127.0.0.1:3001`，并且后端监听在本机 `8001` 端口。
 - `409 任务运行中不能上传文件`：停止当前任务或等待任务结束后再上传更多文件。
-- `开始文档分析任务前，请先上传 Markdown 或 JSON 文件。`：任务消息需要文档分析，但尚未上传 Markdown 或 JSON 文件。
-- `至少需要上传两份投标人文档才能进行对比。`：至少上传两个投标方 Markdown 或 JSON 文件以便进行比较。
+- `开始文档分析任务前，请先上传 Markdown、JSON、TXT、DOCX、XLSX 或 XLSM 文件。`：任务消息需要文档分析，但尚未上传受支持的资源文件。
+- `至少需要上传两份投标人文档才能进行对比。`：至少上传两个投标方 Markdown、JSON、TXT、DOCX、XLSX 或 XLSM 文件以便进行比较。

--- a/asset/bid_analysis_workflow_knowledge_pack.md
+++ b/asset/bid_analysis_workflow_knowledge_pack.md
@@ -18,7 +18,7 @@
 
 - 参考网页的核心不是“一次聊天生成答案”，而是一个可追踪的阶段流水线。每个 run 记录输入、阶段状态、事件、产物、模型配置、skill 引用和最终 compare 结果。
 - 创建分析时需要收集：一份招标文件、一份或多份投标文件、招标评审模型、投标评审模型、图像核验策略，以及 `tender-review`、`bid-review`、`pdf-image-check` 三类 skill 版本引用。
-- MyAgent 当前上传面只支持 `.md` 和 `.json`。引入 PDF 招投标比较时，应新增明确的 PDF ingest 子系统，不能把 PDF 字节静默塞进现有 Markdown/JSON 工作流。
+- MyAgent 当前通用资源上传面支持 `.md`、`.json`、`.txt`、`.docx`、`.xlsx` 和 `.xlsm`。引入 PDF 招投标比较时，应新增明确的 PDF ingest 子系统，不能把 PDF 字节静默塞进现有资源工具工作流。
 - PDF ingest 阶段应为每份文件生成安全中间产物：原始 layout JSON、canonical document JSON、页级 Markdown、可选页面图片、ingest manifest。公开 API 中只暴露 task/run 相对虚拟路径或 artifact ID。
 - 招标文件评审阶段应使用招标 canonical/page Markdown 和后端托管的 skill prompt，生成固定结构的招标评审骨架，覆盖资格、符合性、价格、技术、商务、响应/偏离和特殊规则等章节。
 - 投标文件评审阶段应一次只处理一个投标人，并以招标评审骨架为基线。它必须保持招标侧定义的条目顺序和边界，证据不足时保守标记，并输出固定结构 Markdown。
@@ -97,7 +97,7 @@ skill 引用建议结构：
 
 ## 边界条件
 
-- PDF 支持不能削弱现有 `.md`/`.json` 原子上传校验。PDF 应有独立的文件数量、单文件大小、总请求大小、页数和文件名限制。
+- PDF 支持不能削弱现有 `.md`、`.json`、`.txt`、`.docx`、`.xlsx` 和 `.xlsm` 原子上传校验。PDF 应有独立的文件数量、单文件大小、总请求大小、页数和文件名限制。
 - OCR/VLM/PDF 解析服务属于外部工具。原始响应、签名上传 URL、provider 凭据、绝对路径、全文正文不得进入 task API payload、前端 DOM、复制日志、知识包或测试夹具。
 - 公开产物可以包含 task/run 相对虚拟路径、artifact ID、文件名、页码、短摘录和 hash，不得包含本地私有根路径或第三方签名 URL。
 - Compare HTML 可以嵌入 evidence anchor ID 和短标签，但证据预览 JSON/图片必须通过 MyAgent 自己的鉴权 artifact endpoint 获取。
@@ -191,7 +191,7 @@ npm run build
 
 ## 回归风险
 
-- PDF ingest 会引入大文件、长耗时和外部 provider 失败模式，风险高于当前 Markdown/JSON 流程。
+- PDF ingest 会引入大文件、长耗时和外部 provider 失败模式，风险高于当前通用资源上传流程。
 - 证据预览图片即使不暴露文本，也可能展示敏感文档内容；preview endpoint 必须鉴权、run-scoped。
 - ingest manifest 容易泄漏第三方签名 URL 和本地路径，必须在事件和 API 输出前脱敏。
 - OCR/layout bbox 坐标会受缩放、旋转、裁剪和 DPI 影响，canonical JSON、渲染图片和 preview endpoint 必须使用一致坐标系。

--- a/asset/deepagents_platform_knowledge_pack.md
+++ b/asset/deepagents_platform_knowledge_pack.md
@@ -9,7 +9,7 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 ## Business Rules
 
 - The platform uses `create_deep_agent()` from the `deepagents` SDK as the sole execution engine. It returns a `CompiledStateGraph` ready for `.invoke()` or `.stream()`.
-- `build_agent()` (in `agent/factory.py`) is the default builder; it passes `checkpointer`, `store`, and `max_concurrent_subagents` directly to `create_deep_agent()`.
+- `build_agent()` (in `agent/factory.py`) is the default builder; it passes supported runtime options such as `checkpointer` and `store` directly to `create_deep_agent()`. Do not document or expose config fields as runtime boundaries unless the current SDK call path consumes them.
 - `build_agent_with_middleware()` is an alternative builder that also assembles extra middleware (SkillsMiddleware, SubAgentMiddleware) via `agent/middleware.py` before calling `create_deep_agent()`. **Do NOT use `build_agent_with_middleware()` to add `SummarizationMiddleware`** — it is already auto-injected by `create_deep_agent()`.
 - `create_deep_agent()` auto-injects `TodoListMiddleware`, `FilesystemMiddleware`, `SummarizationMiddleware`, and `PatchToolCallsMiddleware`. Do NOT pass these via the `middleware` parameter — it causes duplicate middleware assertion errors.
 - Skills and SubAgents are passed via `create_deep_agent(skills=..., subagents=...)` keyword arguments, not via the middleware parameter.
@@ -121,6 +121,7 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
 - **Single-process runtime**: The platform uses an in-process runner even though task state is in Postgres. Multi-worker deployment will break cancellation and active-run ownership until a lease/queue design is added.
 - **Timeout enforcement**: `TaskRunner.start()` enforces `settings.agent_timeout_seconds` via `asyncio.timeout()`. If the deepagents SDK or LLM call hangs, the run is terminated after the configured timeout and a warning is logged.
 - **checkpointer/store passthrough**: `build_agent()` passes `checkpointer` and `store` to `create_deep_agent()`, but the current deployment does not use LangGraph-native persistence. Task lifecycle state is managed by Postgres TaskStorage; enabling LangGraph-native persistence would be a separate design.
+- **Configuration drift**: Do not add environment variables or README settings for DeepAgents runtime behavior unless a production call path reads and applies them. Unsupported SDK kwargs, such as a hypothetical subagent concurrency option, should not be presented as active safety boundaries.
 - **LangGraph checkpoint source pin**: `backend/pyproject.toml` pins `langgraph-checkpoint` through `tool.uv.sources` to the `langchain-ai/langgraph` Git commit `2e5025ec1ac8d435840ed4a972097de87aaa2eab` (`libs/checkpoint`). This is intentional: the latest PyPI stable release still emits the startup `LangChainPendingDeprecationWarning`, while that upstream commit already switched `jsonplus.py` to `Reviver(allowed_objects="core")`.
 - **LangGraph v2 stream format**: `agent.astream(..., version="v2")` returns chunks as dicts `{type, ns, data}`, NOT tuples `(namespace, mode, payload)`. Unpacking as a 3-tuple silently iterates dict keys (`"type"`, `"ns"`, `"data"`), causing `mode = "ns"` to be logged and all events dropped. The v2_adapter must check `isinstance(chunk, dict)` and extract `chunk["type"]` / `chunk["data"]`.
 - **Generated Next type files**: `next-env.d.ts` and route types are generated artifacts. Do not review or commit them as source changes; rerun `npm run typecheck` if they are missing locally.
@@ -178,7 +179,7 @@ Use it when changing agent factory, middleware assembly, model provider, tool re
   - `backend/tests/unit/runner/test_memory.py`
   - `backend/tests/unit/security/test_scanner.py`
   - `backend/tests/unit/session/`
-- Runtime contract tests: `backend/tests/unit/api/test_artifacts.py`, `backend/tests/unit/api/test_models.py`, `backend/tests/unit/api/test_tasks.py`, `backend/tests/unit/runner/test_core.py`, `frontend/tests/state/test_task_state.test.ts`, `frontend/tests/workspace/test_task_workspace.test.ts`
+- Runtime contract tests: `backend/tests/unit/api/test_artifacts.py`, `backend/tests/unit/api/test_models.py`, `backend/tests/unit/api/test_tasks.py`, `backend/tests/unit/models/test_config_contract.py`, `backend/tests/unit/runner/test_core.py`, `frontend/tests/state/test_task_state.test.ts`, `frontend/tests/workspace/test_task_workspace.test.ts`
 - Conversation context/store tests: `backend/tests/unit/runner/test_conversation_context.py`, `backend/tests/unit/storage/test_agent_store.py`
 - Automatic title tests: `backend/tests/unit/models/test_task_titles.py`, `backend/tests/unit/api/test_tasks.py`, `backend/tests/unit/storage/test_storage.py`, `frontend/e2e-playwright/test_auto_title_generation.spec.mjs`
 - Resource execution tests: `backend/tests/unit/tools/test_resource_execution.py`, `backend/tests/unit/tools/test_registry.py`, `backend/tests/unit/runner/test_core.py`, `frontend/tests/upload/test_file_upload.test.ts`
@@ -280,7 +281,7 @@ If the task includes pushing a branch, opening/updating a PR, or merging a PR, a
 - SSE resilience regression if frontend reconnect loops become unbounded or backend SSE error payloads are ignored.
 - SSE auth bypass if EventSource query param support is removed without alternative auth.
 - Timeout breakage if `asyncio.timeout()` is removed without an alternative mechanism to prevent runaway agent runs.
-- Concurrency risk if `max_concurrent_subagents` is changed without testing subagent parallel execution limits.
+- Configuration drift risk if README, `Settings`, or knowledge packs expose a runtime knob that is not consumed by the current production call path or accepted by the upstream SDK.
 - SSE event loss if `last_event_id` in `streaming.py` is reverted to `""` — the empty string causes `read_events(after_id="")` to return nothing because `after_id is None` is `False` and no event matches `id == ""`. E2E test `test_sse_drains_remaining_events_before_done` guards this.
 - Event recovery regression if unknown `after_id` values return `[]`. Cursor misses must replay the full ordered stream so frontend deduplication can recover safely without losing terminal events.
 - Stream accumulation regression if `accumulateStreamedAnswer` is reverted to taking only the last delta — this would re-introduce the isolated punctuation card bug.

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@ Local FastAPI backend for the v1 MyAgent workspace.
 ## Scope
 
 - Stores every substantive task in a local task directory.
-- Accepts Markdown and JSON uploads for the v1 document-analysis workflow.
+- Accepts Markdown, JSON, TXT, DOCX, XLSX, and XLSM uploads for the v1 document-analysis workflow.
 - Generates an execution plan before acting.
 - Runs category sub-agents concurrently with retry-on-failure behavior.
 - Persists tool-style events, sub-agent reports, evidence records, final Markdown summary, and an interactive HTML report.
@@ -55,11 +55,22 @@ Copy `.env.example` to `.env` and configure:
 - `DEEPSEEK_API_KEY`
 - `DEEPSEEK_BASE_URL`
 - `TAVILY_API_KEY`
+- `MYAGENT_DATABASE_URL`
+- `MYAGENT_QDRANT_URL`
+- `MYAGENT_QDRANT_COLLECTION`
+- `MYAGENT_DEFAULT_USER_ID`
+- `DASHSCOPE_API_KEY`
+- `MYAGENT_EMBEDDING_BASE_URL`
+- `MYAGENT_EMBEDDING_MODEL`
+- `MYAGENT_EMBEDDING_DIMENSIONS`
 - `MYAGENT_CORS_ORIGINS`
 - `MYAGENT_TASK_ROOT`
 
 The default model registry exposes `deepseek:deepseek-chat`.
 The backend loads `backend/.env` on startup before reading process environment values.
+Startup requires Postgres, Qdrant, and DashScope-compatible embedding configuration:
+missing `MYAGENT_DATABASE_URL`, `MYAGENT_QDRANT_URL`, or `DASHSCOPE_API_KEY`, or an
+unreachable external service, fails startup before the API serves requests.
 Current documentation assumes local same-machine access over `localhost` or `127.0.0.1`.
 Browser callers must use an origin listed in `MYAGENT_CORS_ORIGINS`, which defaults to
 `http://localhost:3001,http://127.0.0.1:3001`. The frontend can use

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,7 +34,6 @@ class Settings:
     # Agent defaults
     default_model: str = "deepseek:deepseek-chat"
     skills_dirs: tuple[str, ...] = ("./skills",)
-    max_concurrent_subagents: int = 3
     agent_timeout_seconds: float = 300.0
     fresh_tool_cache_seconds: int = 600
     recent_message_limit: int = 12
@@ -129,7 +128,6 @@ def load_settings() -> Settings:
         embedding_dimensions=read_int_env("MYAGENT_EMBEDDING_DIMENSIONS", 1024),
         default_model=os.getenv("MYAGENT_DEFAULT_MODEL", "deepseek:deepseek-chat"),
         skills_dirs=skills_dirs,
-        max_concurrent_subagents=read_int_env("MYAGENT_MAX_CONCURRENT_SUBAGENTS", 3),
         agent_timeout_seconds=read_float_env("MYAGENT_AGENT_TIMEOUT_SECONDS", 300.0),
         fresh_tool_cache_seconds=read_int_env("MYAGENT_FRESH_TOOL_CACHE_SECONDS", 600),
         recent_message_limit=read_int_env("MYAGENT_RECENT_MESSAGE_LIMIT", 12),

--- a/backend/tests/unit/models/test_config_contract.py
+++ b/backend/tests/unit/models/test_config_contract.py
@@ -1,0 +1,13 @@
+from app.config import load_settings
+
+
+def test_load_settings_does_not_expose_unsupported_subagent_concurrency_env(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("MYAGENT_TASK_ROOT", str(tmp_path))
+    monkeypatch.setenv("MYAGENT_MAX_CONCURRENT_SUBAGENTS", "9")
+
+    settings = load_settings()
+
+    assert not hasattr(settings, "max_concurrent_subagents")

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,7 +48,7 @@ For every bug fix, feature, or other behavior change, run browser-side E2E again
 Expected backend endpoints:
 
 - `POST /api/tasks` creates a task.
-- `POST /api/tasks/{task_id}/files` uploads Markdown or JSON files as multipart form data.
+- `POST /api/tasks/{task_id}/files` uploads Markdown, JSON, TXT, DOCX, XLSX, or XLSM files as multipart form data.
 - `POST /api/tasks/{task_id}/messages` sends a user message.
 - `POST /api/tasks/{task_id}/cancel` stops a task.
 - `GET /api/tasks/{task_id}` fetches task state, messages, logs, and artifacts.

--- a/frontend/app/task-state.ts
+++ b/frontend/app/task-state.ts
@@ -243,6 +243,7 @@ export type TaskState = {
   status: TaskStatus;
   statusLabel: string;
   model?: string;
+  activeRunId?: string | null;
   runs: TaskRunRecord[];
   messages: ChatMessage[];
   logs: ExecutionLog[];
@@ -1169,6 +1170,7 @@ export function normalizeTaskState(value: unknown, fallbackTaskId: string): Task
     status,
     statusLabel: statusLabel(status, rawStatus),
     model: readOptionalString(record.model),
+    activeRunId: readOptionalString(record.active_run_id ?? record.activeRunId),
     runs: rawRuns.map(normalizeTaskRun),
     messages: rawMessages.map(normalizeMessage),
     logs: rawLogs.map(normalizeLog),

--- a/frontend/tests/state/test_task_state.test.ts
+++ b/frontend/tests/state/test_task_state.test.ts
@@ -26,6 +26,7 @@ function baseState(overrides: Partial<TaskState> = {}): TaskState {
     id: "task-1",
     status: "running",
     statusLabel: "running",
+    activeRunId: null,
     runs: [],
     messages: [],
     logs: [],
@@ -50,6 +51,15 @@ test("normalizeTaskState preserves interrupted as an inactive known status", () 
   assert.equal(state.status, "interrupted");
   assert.equal(state.statusLabel, "interrupted");
   assert.equal(isTaskActive(state.status), false);
+});
+
+test("normalizeTaskState maps active run id from backend state", () => {
+  const state = normalizeTaskState(
+    { task_id: "task-1", status: "running", active_run_id: "run-1" },
+    "fallback",
+  );
+
+  assert.equal(state.activeRunId, "run-1");
 });
 
 test("mergeExecutionLogs appends only new events by id", () => {


### PR DESCRIPTION
## 变更

- 删除未接入生产运行路径的 `max_concurrent_subagents` 后端配置和环境变量读取，避免把 SDK 不支持的参数误描述为运行时边界。
- 给前端 `TaskState` 增加 `activeRunId`，并在 `normalizeTaskState()` 中映射后端 `active_run_id`。
- 同步 README、backend/frontend README、主知识包和招投标知识包的上传格式说明，统一为 `.md`、`.json`、`.txt`、`.docx`、`.xlsx`、`.xlsm`。
- 补齐 backend README 中真实启动需要的 Postgres、Qdrant、DashScope embedding 相关环境变量。
- 在 `AGENTS.md` 写入上传格式同步边界：上传格式是后端校验、前端提示、E2E、README 和知识包共享契约。

## 影响文件

- `backend/app/config.py`
- `backend/tests/unit/models/test_config_contract.py`
- `frontend/app/task-state.ts`
- `frontend/tests/state/test_task_state.test.ts`
- `README.md`
- `backend/README.md`
- `frontend/README.md`
- `asset/deepagents_platform_knowledge_pack.md`
- `asset/bid_analysis_workflow_knowledge_pack.md`
- `AGENTS.md`

## 本地验证

- [x] `cd backend && uv run pytest tests/unit/models/test_config_contract.py` 通过，1 passed
- [x] `cd frontend && node --test --import tsx tests/state/test_task_state.test.ts` 通过，44 passed
- [x] `cd backend && uv run pytest` 通过，207 passed, 3 skipped
- [x] `cd backend && uv run ruff check .` 通过
- [x] `cd backend && uv run mypy app tests` 通过
- [x] `cd frontend && npm ci` 通过，0 vulnerabilities
- [x] `cd frontend && npm test` 通过，131 passed
- [x] `cd frontend && npm run lint` 通过
- [x] `cd frontend && npm run typecheck` 通过
- [x] `cd frontend && npm run build` 通过
- [x] `git diff --check` 通过
- [x] Chrome DevTools MCP 探索：当前工具列表未暴露 DevTools MCP，未使用；最终准入依据为 Playwright
- [x] Playwright E2E：`npx playwright test e2e-playwright/test_runtime_contracts.spec.mjs --reporter=line` 通过，1 passed
- [x] Playwright E2E：`npx playwright test e2e-playwright/test_resource_upload_harness.spec.mjs --reporter=line` 通过，1 passed
- [x] Playwright 截图证据：`frontend/e2e-playwright/e2e-20260514235859/issue-109/`
- [x] 审计账本副本：`audits/agents-audit-20260514-1854/e2e-playwright/issue-109/`

Closes #109

备注：若仓库或分支保护触发远端 CI，本流程会等待远端结果返回后再合并；不会使用 `gh pr merge --auto`。
