### PR TITLE
缺上传澄清与文件交付警告修复

### DIFF
--- a/asset/deepagents_platform_knowledge_pack.md
+++ b/asset/deepagents_platform_knowledge_pack.md
@@ -79,6 +79,8 @@
 - 不同 task/session 可以并行运行；同一 task 运行中必须互斥。
 - `backend/app/api/tasks.py#send_message()` 的同 task 互斥是双层保护：先查 `runner.is_running(task_id)` 返回 409，再由 `storage.start_run(... expected_statuses=...)` 兜底。
 - `backend/app/storage.py#list_task_summaries()` 只把至少有一条非空 user message 的 task 暴露给历史栏；E2E seed 历史时不能只改 title。
+- 缺上传、缺正文且没有可复用上下文时，runner 应在真正启动 agent 前写一条普通 assistant 澄清消息，并结束当前 run；这个场景不应生成用户可见的 `needs_input` warning 或“配置提醒”。
+- `needs_input` 是可继续、可删除、可清空的非运行状态；删除/清空只应阻止 `running` 或 `runner.is_running(task_id)` 仍为真。
 
 ## 事件、SSE 和恢复语义
 
@@ -167,7 +169,9 @@
 - 删除非 running task 必须同时删除 Postgres task row 和 matching local task workspace。
 - task workspace 内真实生成的 `.docx`、`.pptx`、`.xlsx`、`.xlsm`、`.pdf`、`.html`、`.md` 文件需要先通过 run-scoped artifact 登记或安全复制到 `artifacts/runs/{run_id}/`，再暴露给前端下载。
 - 用户明确要求的交付文件，或 final answer 明确声称“已生成/已保存”的文件，必须存在且已登记为当前 run artifact；否则 task/run 不能标记为成功完成。
+- 交付成功优先按当前 run 已登记 artifact 类型判定：Word 看任意 `.docx`，PPT 看任意 `.pptx`，Excel 看任意 `.xlsx`/`.xlsm`，报告看任意 `.html`/`.md`/`.pdf`；只要类型满足请求，就不要因为 final answer 推断出的文件名和 artifact 文件名不同而误报失败。
 - 缺失交付文件时应给出可见的 `文件未生成或未登记为产物` 修正提示，并保持 artifact API 不暴露不可下载的本地路径或伪链接。
+- 真实缺失交付文件时，后台交付保护仍应把 task/run 留在失败修正路径，但前端用户可见 payload 只应暴露简短说明和安全重试入口，不能泄露 `reason`、`repair_hint`、`missing_artifact_names`、`missing_deliverables`、`requested_deliverable_types`、`promoted_artifacts` 等内部字段名。
 - Artifact routes：
   - latest/legacy：`GET /api/tasks/{id}/artifacts/{name}`
   - run-scoped：`GET /api/tasks/{id}/runs/{run_id}/artifacts/{name}`

--- a/backend/app/runner/core.py
+++ b/backend/app/runner/core.py
@@ -610,26 +610,23 @@ class TaskRunner:
         if not missing_kinds and not missing_files:
             return None
 
-        missing_parts: list[str] = []
-        if missing_kinds:
-            missing_parts.append("要求的交付类型缺失：" + "、".join(_humanize_deliverable_kind(kind) for kind in missing_kinds))
-        if missing_files:
-            missing_parts.append("声称已生成的文件缺失：" + "、".join(missing_files))
-        message = "文件未生成或未登记为产物，请修复后重新生成。"
-        payload: dict[str, Any] = {
+        if missing_kinds or missing_files:
+            logger.warning(
+                "Run deliverable validation failed",
+                extra={
+                    "task_id": task_id,
+                    "run_id": run_id,
+                    "missing_deliverable_kinds": sorted(missing_kinds),
+                    "missing_artifact_names": sorted(missing_files),
+                    "promoted_artifacts": promoted,
+                },
+            )
+
+        message = "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。"
+        return {
             "message": message,
-            "reason": "deliverable_artifact_missing",
-            "missing_deliverables": missing_parts,
-            "missing_artifact_names": missing_files,
-            "promoted_artifacts": promoted,
-            "repair_hint": "请在当前任务工作区生成文件并登记为 artifact 后重试。",
             "action_label": "重新生成文件",
         }
-        if missing_kinds:
-            payload["requested_deliverable_types"] = [
-                _humanize_deliverable_kind(kind) for kind in missing_kinds
-            ]
-        return payload
 
     def _missing_source_input_clarification(
         self,

--- a/backend/app/runner/core.py
+++ b/backend/app/runner/core.py
@@ -55,6 +55,11 @@ CLAIMED_FILE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 DELIVERABLE_SEARCH_EXCLUDED_DIRS = {"artifacts", "uploads", ".git", "__pycache__"}
+SOURCE_DEPENDENT_REQUEST_PATTERN = re.compile(
+    r"(总结|汇总|概括|摘要|提炼|归纳|梳理|分析|阅读|整理|summari[sz]e|summary|analy[sz]e)",
+    re.IGNORECASE,
+)
+INLINE_SOURCE_MIN_CHARS = 24
 
 
 class RunnerStorage(Protocol):
@@ -287,6 +292,46 @@ class TaskRunner:
                 )
 
             try:
+                missing_source_clarification = self._missing_source_input_clarification(
+                    task_id=task_id,
+                    run_id=run_id,
+                    user_message=message,
+                )
+                if missing_source_clarification is not None:
+                    clarification_message = ChatMessage(
+                        role="assistant",
+                        content=missing_source_clarification,
+                        created_at="",
+                        run_id=run_id,
+                    )
+                    self.storage.update_task_if_status_and_append_event(
+                        task_id,
+                        {"running"},
+                        status="complete",
+                        run_id=run_id,
+                        append_message=clarification_message,
+                        event_type="task_completed",
+                        event_message="已请求补充文件或内容。",
+                        event_payload=_terminal_event_payload(
+                            "已请求补充文件或内容",
+                            stage="completed",
+                            previous_status="running",
+                        ),
+                        event_level="success",
+                    )
+                    storage.append_event(
+                        task_id,
+                        "final_answer",
+                        "Final answer generated",
+                        payload={
+                            "content": missing_source_clarification,
+                            "live": _answer_completed_live_metadata(),
+                        },
+                        run_id=run_id,
+                        level="success",
+                    )
+                    return
+
                 collected, final_state = await self.start(
                     task_id, message, model=model, run_id=run_id, on_event=_append_event,
                 )
@@ -583,6 +628,40 @@ class TaskRunner:
             ]
         return payload
 
+    def _missing_source_input_clarification(
+        self,
+        *,
+        task_id: str,
+        run_id: str,
+        user_message: str,
+    ) -> str | None:
+        storage = self.storage
+        if storage is None or not _requests_source_dependent_work(user_message):
+            return None
+
+        try:
+            state = storage.get_task(task_id, include_events=False)
+        except Exception:
+            logger.warning(
+                "Unable to inspect task %s before missing-source clarification", task_id, exc_info=True
+            )
+            return None
+
+        if state.upload_count > 0:
+            return None
+        if _message_contains_inline_source_text(user_message):
+            return None
+        if _has_reusable_source_context(state.messages, current_run_id=run_id):
+            return None
+        if _has_context_summary(storage, task_id):
+            return None
+
+        deliverable_kinds = _requested_deliverable_kinds(user_message)
+        if deliverable_kinds:
+            kind_label = _humanize_deliverable_kind(sorted(deliverable_kinds)[0])
+            return f"你是不是忘记上传文件了？上传后我继续帮你生成 {kind_label}。"
+        return "你是不是忘记上传文件或粘贴要处理的内容了？补充后我继续帮你总结。"
+
 
 def _make_runner_event(
     task_id: str,
@@ -666,6 +745,68 @@ def _requested_deliverable_kinds(message: str) -> set[str]:
         if re.search(pattern, normalized, re.IGNORECASE):
             requested.add(kind)
     return requested
+
+
+def _requests_source_dependent_work(message: str) -> bool:
+    if _requested_deliverable_kinds(message):
+        return True
+    return SOURCE_DEPENDENT_REQUEST_PATTERN.search(message) is not None
+
+
+def _message_contains_inline_source_text(message: str) -> bool:
+    normalized = " ".join(message.split())
+    if len(_source_signal_text(normalized)) >= 80:
+        return True
+    for separator in ("\n", "：", ":"):
+        if separator not in message:
+            continue
+        tail = message.rsplit(separator, 1)[-1]
+        if len(_source_signal_text(tail)) >= INLINE_SOURCE_MIN_CHARS:
+            return True
+    return False
+
+
+def _has_reusable_source_context(messages: list[ChatMessage], *, current_run_id: str) -> bool:
+    for message in messages:
+        if message.run_id == current_run_id:
+            continue
+        content = message.content.strip()
+        if not content:
+            continue
+        if message.role == "user":
+            if _message_contains_inline_source_text(content):
+                return True
+            if not _requests_source_dependent_work(content) and len(_source_signal_text(content)) >= 40:
+                return True
+        elif message.role == "assistant":
+            if "忘记上传文件" in content:
+                continue
+            if len(_source_signal_text(content)) >= 120:
+                return True
+    return False
+
+
+def _source_signal_text(text: str) -> str:
+    without_common_request_terms = re.sub(
+        r"(请|帮我|帮忙|总结|汇总|概括|摘要|提炼|归纳|梳理|分析|阅读|整理|生成|导出|输出|交付|提供|保存|"
+        r"word|docx|ppt|pptx|excel|xlsx|xlsm|报告|文档|文件|内容|材料|资料|文本|一下|一个|一份|给我)",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+    return "".join(ch for ch in without_common_request_terms if ch.isalnum())
+
+
+def _has_context_summary(storage: RunnerStorage, task_id: str) -> bool:
+    get_context_summary = getattr(storage, "get_context_summary", None)
+    if not callable(get_context_summary):
+        return False
+    try:
+        summary = get_context_summary(task_id)
+    except Exception:
+        logger.warning("Unable to inspect task %s context summary", task_id, exc_info=True)
+        return False
+    return bool(str(summary or "").strip())
 
 
 def _claimed_output_filenames(final_answer: str | None) -> set[str]:

--- a/backend/app/runner/core.py
+++ b/backend/app/runner/core.py
@@ -600,6 +600,9 @@ class TaskRunner:
         missing_kinds = [
             kind for kind in sorted(expected_kinds) if _kind_to_suffixes(kind).isdisjoint(artifact_suffixes)
         ]
+        if expected_kinds and not missing_kinds:
+            return None
+
         missing_files = [
             name for name in sorted(claimed_files) if name.casefold() not in artifact_names
         ]

--- a/backend/tests/unit/api/test_tasks.py
+++ b/backend/tests/unit/api/test_tasks.py
@@ -285,6 +285,39 @@ class TestTaskHistoryActions:
         assert app_client.get(f"/api/tasks/{task_id}").status_code == 404
         assert not task_dir.exists()
 
+    @pytest.mark.parametrize(
+        "terminal_status",
+        ["complete", "failed", "cancelled", "needs_input", "interrupted"],
+    )
+    def test_delete_allows_inactive_terminal_statuses(
+        self, terminal_status, create_idle_task, app_client
+    ):
+        created = create_idle_task()
+        task_id = created["task_id"]
+        storage = app_client.app.state.storage
+        run_result = storage.start_run(
+            task_id,
+            message="hello",
+            model="deepseek-v4-flash",
+            expected_statuses={"idle"},
+        )
+        assert run_result is not None
+        _, run_id = run_result
+        needs_input = {"message": "请补充文件"} if terminal_status == "needs_input" else None
+        updated = storage.update_task_if_status(
+            task_id,
+            {"running"},
+            status=terminal_status,
+            run_id=run_id,
+            needs_input=needs_input,
+        )
+        assert updated is not None
+
+        response = app_client.delete(f"/api/tasks/{task_id}")
+
+        assert response.status_code == 204
+        assert app_client.get(f"/api/tasks/{task_id}").status_code == 404
+
     def test_delete_running_task_returns_409(self, create_idle_task, app_client):
         created = create_idle_task()
         task_id = created["task_id"]
@@ -300,6 +333,23 @@ class TestTaskHistoryActions:
 
         assert response.status_code == 409
         assert response.json()["detail"] == "任务运行中，不能删除"
+
+    def test_delete_runner_active_task_returns_409_even_when_state_is_not_running(
+        self, create_idle_task, app_client
+    ):
+        created = create_idle_task()
+        task_id = created["task_id"]
+        runner = app_client.app.state.runner
+        original_is_running = runner.is_running
+        runner.is_running = lambda candidate_task_id: candidate_task_id == task_id
+        try:
+            response = app_client.delete(f"/api/tasks/{task_id}")
+        finally:
+            runner.is_running = original_is_running
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "任务运行中，不能删除"
+        assert app_client.get(f"/api/tasks/{task_id}").status_code == 200
 
 
 class TestGetEvents:

--- a/backend/tests/unit/runner/test_conversation_context.py
+++ b/backend/tests/unit/runner/test_conversation_context.py
@@ -4,6 +4,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from app.config import Settings
 from app.conversation_context import ConversationContextBuilder
+from app.execution.resources import build_resource_manifest, format_resource_manifest_message
 from app.schemas import ChatMessage
 from tests.fakes import InMemoryTaskStorage
 
@@ -51,6 +52,62 @@ def test_context_builder_injects_previous_messages_without_current_tail(tmp_path
     assert any("上海今日天气" in content for content in contents)
     assert all(content != "我刚才问了什么？" for content in contents)
     assert context.event_payload()["recent_message_count"] == 2
+
+
+def test_file_only_followup_keeps_previous_intent_and_upload_manifest(tmp_path):
+    settings = Settings(
+        task_root=tmp_path / "tasks",
+        workspace_root=tmp_path / "tasks",
+        recent_message_limit=12,
+    )
+    storage = InMemoryTaskStorage(settings.task_root)
+    state = storage.create_task(message=None, model="deepseek-v4-flash")
+    first_run = storage.start_run(
+        state.task_id,
+        message="总结内容并生成 Word",
+        model="deepseek-v4-flash",
+        expected_statuses={"idle"},
+    )
+    assert first_run is not None
+    _, first_run_id = first_run
+    storage.update_task_if_status_and_append_event(
+        state.task_id,
+        {"running"},
+        status="complete",
+        run_id=first_run_id,
+        append_message=ChatMessage(
+            role="assistant",
+            content="你是不是忘记上传文件了？上传后我继续帮你生成 Word。",
+            created_at="",
+        ),
+        event_type="task_completed",
+        event_message="任务已完成。",
+    )
+    upload_dir = settings.workspace_root / state.task_id / "uploads"
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    (upload_dir / "source.md").write_text("# 招标材料\n这是待总结正文。", encoding="utf-8")
+    followup_message = "我已上传文件，请继续上一轮需求：总结内容并生成 Word。本轮文件：source.md。"
+    followup = storage.start_run(
+        state.task_id,
+        message=followup_message,
+        model="deepseek-v4-flash",
+        expected_statuses={"complete"},
+    )
+    assert followup is not None
+
+    context = ConversationContextBuilder(settings, storage).build(
+        task_id=state.task_id,
+        current_message=followup_message,
+    )
+    serialized_context = "\n".join(str(message.content) for message in context.messages)
+    manifest_text = format_resource_manifest_message(
+        build_resource_manifest(state.task_id, settings.workspace_root)
+    )
+
+    assert "总结内容并生成 Word" in serialized_context
+    assert followup_message not in serialized_context
+    assert "source.md" in manifest_text
+    assert "这是待总结正文" not in manifest_text
 
 
 def test_context_builder_summarizes_long_history(tmp_path):

--- a/backend/tests/unit/runner/test_core.py
+++ b/backend/tests/unit/runner/test_core.py
@@ -380,15 +380,66 @@ class TestTaskRunnerTerminalEvents:
         assert final_answers[0].payload["live"]["display_text"] == "回答已完成"
 
     @pytest.mark.asyncio
+    async def test_background_run_clarifies_missing_upload_as_assistant_message(
+        self, test_settings, monkeypatch
+    ):
+        storage = InMemoryTaskStorage(test_settings.task_root)
+        runner = TaskRunner(test_settings, storage)
+        state = storage.create_task(message=None, model="deepseek-v4-flash")
+        user_message = "请总结内容并生成 Word"
+        run_result = storage.start_run(
+            state.task_id,
+            message=user_message,
+            model="deepseek-v4-flash",
+            expected_statuses={"idle"},
+        )
+        assert run_result is not None
+        _, run_id = run_result
+
+        async def fail_if_agent_starts(*args, **kwargs):
+            raise AssertionError("missing-source clarification should not start the agent")
+
+        monkeypatch.setattr(runner, "start", fail_if_agent_starts)
+
+        runner.start_background(
+            state.task_id,
+            user_message,
+            model="deepseek-v4-flash",
+            run_id=run_id,
+        )
+        await _wait_for_runner(runner, state.task_id)
+
+        task_state = storage.get_task(state.task_id)
+        assistant_messages = [message for message in task_state.messages if message.role == "assistant"]
+        needs_input_events = [event for event in task_state.events if event.type == "needs_input"]
+        final_answers = [event for event in task_state.events if event.type == "final_answer"]
+
+        assert task_state.status == "complete"
+        assert task_state.needs_input is None
+        assert task_state.runs[-1].status == "complete"
+        assert task_state.runs[-1].needs_input is None
+        assert needs_input_events == []
+        assert len(assistant_messages) == 1
+        assert "你是不是忘记上传文件了" in assistant_messages[0].content
+        assert "继续帮你生成 Word" in assistant_messages[0].content
+        assert len(final_answers) == 1
+        assert final_answers[0].level == "success"
+        assert final_answers[0].payload["content"] == assistant_messages[0].content
+
+    @pytest.mark.asyncio
     async def test_background_run_requires_requested_deliverable_artifact_before_complete(
         self, test_settings, monkeypatch
     ):
         storage = InMemoryTaskStorage(test_settings.task_root)
         runner = TaskRunner(test_settings, storage)
         state = storage.create_task(message=None, model="deepseek-v4-flash")
+        user_message = (
+            "请根据以下项目材料生成一份 Word 文档并交付给我：\n"
+            "项目A在第一阶段完成需求调研、接口梳理、风险识别和交付计划确认，需要形成正式文档。"
+        )
         run_result = storage.start_run(
             state.task_id,
-            message="请生成一份 Word 文档并交付给我",
+            message=user_message,
             model="deepseek-v4-flash",
             expected_statuses={"idle"},
         )
@@ -402,7 +453,7 @@ class TestTaskRunnerTerminalEvents:
 
         runner.start_background(
             state.task_id,
-            "请生成一份 Word 文档并交付给我",
+            user_message,
             model="deepseek-v4-flash",
             run_id=run_id,
         )
@@ -430,9 +481,13 @@ class TestTaskRunnerTerminalEvents:
         storage = InMemoryTaskStorage(test_settings.task_root)
         runner = TaskRunner(test_settings, storage)
         state = storage.create_task(message=None, model="deepseek-v4-flash")
+        user_message = (
+            "请根据以下材料输出简短总结，并把 Word 文档交付给我：\n"
+            "本轮会议确认了实施范围、交付节点、风险负责人和后续验收安排。"
+        )
         run_result = storage.start_run(
             state.task_id,
-            message="请输出简短总结，并把 Word 文档交付给我",
+            message=user_message,
             model="deepseek-v4-flash",
             expected_statuses={"idle"},
         )
@@ -449,7 +504,7 @@ class TestTaskRunnerTerminalEvents:
 
         runner.start_background(
             state.task_id,
-            "请输出简短总结，并把 Word 文档交付给我",
+            user_message,
             model="deepseek-v4-flash",
             run_id=run_id,
         )

--- a/backend/tests/unit/runner/test_core.py
+++ b/backend/tests/unit/runner/test_core.py
@@ -469,9 +469,23 @@ class TestTaskRunnerTerminalEvents:
         assert final_answers == []
         assert len(needs_input_events) == 1
         assert needs_input_events[0].run_id == run_id
-        assert "文件未生成或未登记为产物" in needs_input_events[0].message
+        assert "文件未成功生成或未能登记为下载文件" in needs_input_events[0].message
         assert task_state.needs_input is not None
-        assert task_state.needs_input["reason"] == "deliverable_artifact_missing"
+        assert task_state.needs_input == {
+            "message": "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。",
+            "action_label": "重新生成文件",
+        }
+        assert needs_input_events[0].payload == task_state.needs_input
+        for internal_key in (
+            "reason",
+            "repair_hint",
+            "missing_artifact_names",
+            "missing_deliverables",
+            "requested_deliverable_types",
+            "promoted_artifacts",
+        ):
+            assert internal_key not in task_state.needs_input
+            assert internal_key not in needs_input_events[0].payload
         assert task_state.runs[-1].status == "needs_input"
 
     @pytest.mark.parametrize(

--- a/backend/tests/unit/runner/test_core.py
+++ b/backend/tests/unit/runner/test_core.py
@@ -474,6 +474,68 @@ class TestTaskRunnerTerminalEvents:
         assert task_state.needs_input["reason"] == "deliverable_artifact_missing"
         assert task_state.runs[-1].status == "needs_input"
 
+    @pytest.mark.parametrize(
+        ("request_phrase", "artifact_name", "claimed_name"),
+        [
+            ("生成一份 Word 文档", "actual-summary.docx", "model-summary.docx"),
+            ("生成一份 PPT 幻灯片", "actual-slides.pptx", "model-slides.pptx"),
+            ("生成一份 Excel 表格", "actual-workbook.xlsx", "model-workbook.xlsx"),
+            ("生成一份 Excel 表格", "actual-macro-workbook.xlsm", "model-workbook.xlsx"),
+            ("生成一份报告", "actual-report.html", "model-report.html"),
+            ("生成一份报告", "actual-report.md", "model-report.pdf"),
+            ("生成一份报告", "actual-report.pdf", "model-report.html"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_background_run_accepts_any_artifact_matching_requested_deliverable_type(
+        self,
+        test_settings,
+        monkeypatch,
+        request_phrase: str,
+        artifact_name: str,
+        claimed_name: str,
+    ):
+        storage = InMemoryTaskStorage(test_settings.task_root)
+        runner = TaskRunner(test_settings, storage)
+        state = storage.create_task(message=None, model="deepseek-v4-flash")
+        user_message = (
+            f"请根据以下材料{request_phrase}并交付给我：\n"
+            "项目资料包含范围边界、进度安排、风险负责人、验收方式和预算调整说明。"
+        )
+        run_result = storage.start_run(
+            state.task_id,
+            message=user_message,
+            model="deepseek-v4-flash",
+            expected_statuses={"idle"},
+        )
+        assert run_result is not None
+        _, run_id = run_result
+        storage.write_run_text(state.task_id, run_id, artifact_name, "placeholder")
+
+        async def fake_start(*args, **kwargs):
+            return [], {"messages": [AIMessage(content=f"已生成 {claimed_name}，请下载查看。")]}
+
+        monkeypatch.setattr(runner, "start", fake_start)
+
+        runner.start_background(
+            state.task_id,
+            user_message,
+            model="deepseek-v4-flash",
+            run_id=run_id,
+        )
+        await _wait_for_runner(runner, state.task_id)
+
+        task_state = storage.get_task(state.task_id)
+        needs_input_events = [event for event in task_state.events if event.type == "needs_input"]
+        final_answers = [event for event in task_state.events if event.type == "final_answer"]
+
+        assert task_state.status == "complete"
+        assert task_state.needs_input is None
+        assert task_state.runs[-1].status == "complete"
+        assert artifact_name in task_state.runs[-1].artifact_names
+        assert needs_input_events == []
+        assert len(final_answers) == 1
+
     @pytest.mark.asyncio
     async def test_background_run_promotes_claimed_workspace_file_before_complete(
         self, test_settings, monkeypatch

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -704,6 +704,64 @@ p {
   line-height: 1.7;
 }
 
+.userMessageFileList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.userMessageFileChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  max-width: min(280px, 100%);
+  min-height: 30px;
+  padding: 6px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--on-primary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
+}
+
+.userMessageFileIcon {
+  position: relative;
+  width: 14px;
+  height: 17px;
+  flex: 0 0 auto;
+  border: 1.5px solid currentColor;
+  border-radius: 3px;
+  opacity: 0.84;
+}
+
+.userMessageFileIcon::before {
+  position: absolute;
+  top: -1.5px;
+  right: -1.5px;
+  width: 6px;
+  height: 6px;
+  border-bottom: 1.5px solid currentColor;
+  border-left: 1.5px solid currentColor;
+  border-radius: 0 3px 0 2px;
+  background: var(--primary);
+  content: "";
+}
+
+.userMessageFileName {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--on-primary);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .userMessageMeta {
   display: flex;
   align-items: center;
@@ -2860,6 +2918,11 @@ button:hover:not(:disabled),
 
   .fileChip {
     width: 100%;
+  }
+
+  .userMessageFileChip {
+    width: 100%;
+    max-width: 100%;
   }
 
   .replaceFileButton {

--- a/frontend/app/task-state.ts
+++ b/frontend/app/task-state.ts
@@ -1033,6 +1033,7 @@ function normalizeAssistantThinkingStream(type: string | undefined, payload: Rec
 
 const GENERATED_FILE_ONLY_MESSAGE_PREFIXES = [
   "请继续上一轮需求",
+  "我已上传文件，请继续上一轮需求",
   "我已上传文件，请读取并处理本轮上传资源",
 ];
 

--- a/frontend/app/task-state.ts
+++ b/frontend/app/task-state.ts
@@ -21,10 +21,16 @@ export type ChatMessage = {
   id: string;
   role: "user" | "assistant" | "system";
   content: string;
+  files?: ChatMessageFile[];
+  fileOnly?: boolean;
   createdAt?: string;
   runId?: string | null;
   level?: "info" | "warning" | "error";
   streaming?: boolean;
+};
+
+export type ChatMessageFile = {
+  name: string;
 };
 
 export type ExecutionLog = {
@@ -1000,16 +1006,84 @@ function normalizeAssistantThinkingStream(type: string | undefined, payload: Rec
   };
 }
 
+const GENERATED_FILE_ONLY_MESSAGE_PREFIXES = [
+  "请继续上一轮需求",
+  "我已上传文件，请读取并处理本轮上传资源",
+];
+
+function readFileName(value: unknown) {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (!isRecord(value)) {
+    return "";
+  }
+  return readString(value.name ?? value.filename ?? value.file_name ?? value.fileName, "").trim();
+}
+
+function normalizeMessageFilesFromValue(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const files: ChatMessageFile[] = [];
+  value.forEach((item) => {
+    const name = readFileName(item);
+    if (!name || seen.has(name)) {
+      return;
+    }
+    seen.add(name);
+    files.push({ name });
+  });
+  return files;
+}
+
+function extractFileOnlyMessageFiles(content: string) {
+  const match = content.match(/本轮文件[:：]\s*([^。！?\n]+)(?:[。！?]|\n|$)/);
+  if (!match) {
+    return [];
+  }
+
+  const fileList = match[1].replace(/\s+等\s+\d+\s+个文件\s*$/u, "").trim();
+  if (!fileList || fileList === "本轮已上传文件") {
+    return [];
+  }
+  return normalizeMessageFilesFromValue(fileList.split("、"));
+}
+
+function isGeneratedFileOnlyMessage(content: string) {
+  const normalizedContent = content.trim();
+  return GENERATED_FILE_ONLY_MESSAGE_PREFIXES.some((prefix) => normalizedContent.startsWith(prefix));
+}
+
+function normalizeMessageFiles(record: Record<string, unknown>, content: string, role: ChatMessage["role"]) {
+  const explicitFiles = normalizeMessageFilesFromValue(
+    record.files ?? record.uploads ?? record.attachments ?? record.uploaded_files ?? record.uploadedFiles,
+  );
+  if (explicitFiles.length > 0) {
+    return explicitFiles;
+  }
+  if (role !== "user" || !isGeneratedFileOnlyMessage(content)) {
+    return [];
+  }
+  return extractFileOnlyMessageFiles(content);
+}
+
 function normalizeMessage(value: unknown, index: number): ChatMessage {
   const record = isRecord(value) ? value : {};
   const role = readString(record.role, "assistant");
   const normalizedRole = role === "user" || role === "system" ? role : "assistant";
   const level = readLevel(record.level);
   const rawContent = readString(record.content ?? record.text ?? record.message, "");
+  const files = normalizeMessageFiles(record, rawContent, normalizedRole);
+  const fileOnly = normalizedRole === "user" && files.length > 0 && isGeneratedFileOnlyMessage(rawContent);
   return {
     id: readString(record.id, `message-${index}`),
     role: normalizedRole,
     content: normalizedRole === "user" ? rawContent : translateKnownDisplayText(rawContent),
+    ...(files.length > 0 ? { files } : {}),
+    ...(fileOnly ? { fileOnly: true } : {}),
     createdAt: readOptionalString(record.created_at ?? record.createdAt),
     runId: maybeRunId(record),
     level: level === "success" ? undefined : level,

--- a/frontend/app/task-state.ts
+++ b/frontend/app/task-state.ts
@@ -555,6 +555,8 @@ const KNOWN_DISPLAY_TEXT: Record<string, string> = {
   "Task was interrupted because no active runner owns it.": "任务已中断：当前没有运行器接管该任务。",
   "Upload Markdown or JSON files before starting a document-analysis task.": "开始文档分析任务前，请先上传 Markdown、JSON、TXT、DOCX、XLSX 或 XLSM 文件。",
   "At least two uploaded bidder documents are required for comparison.": "至少需要上传两份投标人文档才能进行对比。",
+  "文件未生成或未登记为产物，请修复后重新生成。": "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。",
+  "文件未生成或未登记为产物，请重新生成交付文件后再提交。": "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。",
   "Execution plan generated": "已生成执行计划。",
   "Concurrent sub-agent analysis started": "并发子任务分析已开始。",
   "Final report artifacts were written": "最终报告产物已写入。",
@@ -649,6 +651,8 @@ function formatNeedsInputKey(key: string) {
     minimum_bidder_documents: "至少投标人文档数",
     current_bidder_documents: "当前投标人文档数",
     required_file_type: "所需文件类型",
+    action_label: "建议操作",
+    actionLabel: "建议操作",
   };
   return labels[key] ?? key;
 }
@@ -661,11 +665,32 @@ function formatNeedsInputValue(key: string, value: unknown) {
 }
 
 export function formatNeedsInput(value: Record<string, unknown>) {
-  const message = translateKnownDisplayText(readString(value.message, "Additional input is required."));
-  const details = Object.entries(value)
+  const publicValue = sanitizeNeedsInput(value);
+  const message = translateKnownDisplayText(readString(publicValue.message, "Additional input is required."));
+  const details = Object.entries(publicValue)
     .filter(([key]) => key !== "message")
     .map(([key, entry]) => `${formatNeedsInputKey(key)}：${formatNeedsInputValue(key, entry)}`);
   return details.length > 0 ? `${message} ${details.join(" · ")}` : message;
+}
+
+const INTERNAL_NEEDS_INPUT_KEYS = new Set([
+  "reason",
+  "repair_hint",
+  "repairHint",
+  "missing_artifact_names",
+  "missingArtifactNames",
+  "missing_deliverables",
+  "missingDeliverables",
+  "requested_deliverable_types",
+  "requestedDeliverableTypes",
+  "promoted_artifacts",
+  "promotedArtifacts",
+]);
+
+function sanitizeNeedsInput(value: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => !INTERNAL_NEEDS_INPUT_KEYS.has(key)),
+  );
 }
 
 function normalizeStatus(value: unknown): TaskStatus {
@@ -678,7 +703,7 @@ function statusLabel(status: TaskStatus, rawStatus: string) {
 }
 
 function readOptionalNeedsInput(value: unknown) {
-  return isRecord(value) ? value : null;
+  return isRecord(value) ? sanitizeNeedsInput(value) : null;
 }
 
 function maybeRunId(record: Record<string, unknown>) {

--- a/frontend/app/workspace-view.ts
+++ b/frontend/app/workspace-view.ts
@@ -124,7 +124,7 @@ export function buildStateNoticeMessages(
       id: "state:needs-input",
       role: "assistant",
       content: needsInputContent,
-      level: "warning",
+      level: "error",
     });
   }
 
@@ -1646,8 +1646,20 @@ export function isWarningChatMessage(message: ChatMessage) {
   );
 }
 
+function isDeliverableFailureMessage(message: ChatMessage) {
+  const content = message.content.trim();
+  return (
+    message.role === "assistant" &&
+    (content.includes("文件未成功生成或未能登记为下载文件") ||
+      content.includes("文件未生成或未登记为产物"))
+  );
+}
+
 export function getMessagePanelTone(message: ChatMessage): MessagePanelTone {
   if (message.level === "error") {
+    return "error";
+  }
+  if (isDeliverableFailureMessage(message)) {
     return "error";
   }
   if (isWarningChatMessage(message)) {

--- a/frontend/components/chat/TaskConversation.tsx
+++ b/frontend/components/chat/TaskConversation.tsx
@@ -166,6 +166,31 @@ export function TaskConversation({
     return artifactKind === "html" || artifact.name.toLowerCase().endsWith(".html");
   }
 
+  function buildUserCopyText(message: ChatMessage) {
+    if (message.content) {
+      return message.content;
+    }
+    return (message.files ?? []).map((file) => file.name).join("\n");
+  }
+
+  function renderUserMessageFiles(message: ChatMessage) {
+    if (!message.files || message.files.length === 0) {
+      return null;
+    }
+    return (
+      <div className="userMessageFileList" aria-label="已上传文件">
+        {message.files.map((file, index) => (
+          <span className="userMessageFileChip" key={`${message.id}:${file.name}:${index}`}>
+            <span className="userMessageFileIcon" aria-hidden="true" />
+            <span className="userMessageFileName" title={file.name}>
+              {file.name}
+            </span>
+          </span>
+        ))}
+      </div>
+    );
+  }
+
   function renderChatMessage(
     message: ChatMessage,
     key: string,
@@ -184,6 +209,8 @@ export function TaskConversation({
     if (message.role === "user") {
       const userCopyKey = `message:${message.id}:user`;
       const isUserMessageCopied = copiedCopyKey === userCopyKey;
+      const userMessageContent = message.fileOnly ? "" : message.content;
+      const userCopyText = buildUserCopyText(message);
       const userCopyButtonClassName = [
         "copyButton",
         "userCopyButton",
@@ -196,15 +223,16 @@ export function TaskConversation({
         <div className="userMessageRow" key={key}>
           <div className="userMessageFrame">
             <article className={messageClassName}>
-              <p>{message.content}</p>
+              {userMessageContent ? <p>{userMessageContent}</p> : null}
+              {renderUserMessageFiles(message)}
             </article>
             <div className="userMessageMeta">
               <time className="userMessageTime">{formatTime(message.createdAt, "short")}</time>
               <button
                 aria-label={isUserMessageCopied ? "已复制用户消息" : "复制用户消息"}
                 className={userCopyButtonClassName}
-                disabled={!message.content}
-                onClick={() => void onCopyText(message.content, undefined, userCopyKey)}
+                disabled={!userCopyText}
+                onClick={() => void onCopyText(userCopyText, undefined, userCopyKey)}
                 title={isUserMessageCopied ? "已复制" : "复制用户消息"}
                 type="button"
               >

--- a/frontend/e2e-playwright/test_missing_upload_clarification_delivery_warning.spec.mjs
+++ b/frontend/e2e-playwright/test_missing_upload_clarification_delivery_warning.spec.mjs
@@ -1,0 +1,622 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+const BASE_URL = process.env.MYAGENT_E2E_BASE_URL || "http://127.0.0.1:3001";
+const API_URL = process.env.MYAGENT_E2E_API_URL || "http://127.0.0.1:8001";
+const TASK_ROOT = process.env.MYAGENT_E2E_TASK_ROOT;
+const EVIDENCE_DIR = process.env.MYAGENT_E2E_EVIDENCE_DIR;
+const ACCESS_TOKEN = process.env.MYAGENT_E2E_ACCESS_TOKEN || "";
+const POSTGRES_CONTAINER = process.env.MYAGENT_E2E_POSTGRES_CONTAINER || "PostgreSQL";
+const POSTGRES_USER = process.env.MYAGENT_E2E_POSTGRES_USER || "postgres";
+const POSTGRES_DB = process.env.MYAGENT_E2E_POSTGRES_DB || "myagent";
+
+const INTERNAL_DELIVERY_FIELDS = [
+  "reason",
+  "repair_hint",
+  "missing_artifact_names",
+  "missing_deliverables",
+  "requested_deliverable_types",
+  "promoted_artifacts",
+];
+
+function requirePath(value, name) {
+  if (!value) {
+    throw new Error(`${name} is required for missing-upload-delivery-warning E2E`);
+  }
+  return value;
+}
+
+function authHeaders() {
+  return ACCESS_TOKEN ? { "X-MyAgent-Token": ACCESS_TOKEN } : {};
+}
+
+function nowIso(offsetMs = 0) {
+  return new Date(Date.now() + offsetMs).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function sqlJson(value) {
+  return `${sqlString(JSON.stringify(value))}::jsonb`;
+}
+
+function runSql(sql) {
+  execFileSync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      POSTGRES_CONTAINER,
+      "psql",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-U",
+      POSTGRES_USER,
+      "-d",
+      POSTGRES_DB,
+    ],
+    {
+      input: sql,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+}
+
+function appendEventSql(taskId, event) {
+  return `
+WITH next_seq AS (
+  UPDATE tasks
+  SET latest_event_seq = latest_event_seq + 1
+  WHERE task_id = ${sqlString(taskId)}
+  RETURNING latest_event_seq
+)
+INSERT INTO events (
+  id, task_id, seq, type, message, created_at, payload, run_id, level, idempotency_key
+)
+SELECT
+  ${sqlString(event.id ?? randomUUID().replaceAll("-", ""))},
+  ${sqlString(taskId)},
+  latest_event_seq,
+  ${sqlString(event.type)},
+  ${sqlString(event.message)},
+  ${sqlString(event.createdAt)},
+  ${sqlJson(event.payload ?? {})},
+  ${event.runId ? sqlString(event.runId) : "NULL"},
+  ${event.level ? sqlString(event.level) : "NULL"},
+  NULL
+FROM next_seq;
+`;
+}
+
+function ensureTaskWorkspace(taskRoot, taskId) {
+  const taskDir = path.join(taskRoot, taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  return taskDir;
+}
+
+function writeUploadFixture(evidenceDir) {
+  const fixtureDir = path.join(evidenceDir, "fixtures");
+  fs.mkdirSync(fixtureDir, { recursive: true });
+  const fixturePath = path.join(fixtureDir, "clarification-brief.txt");
+  fs.writeFileSync(
+    fixturePath,
+    [
+      "项目背景：本文件用于缺上传澄清后的继续处理验收。",
+      "需要输出：请延续上一轮需求，总结内容并生成 Word。",
+      "截图要求：不要包含任何客户资料或密钥。",
+    ].join("\n"),
+    "utf8",
+  );
+  return fixturePath;
+}
+
+function seedContinuationDocxRun(taskRoot, taskId, userMessage) {
+  const timestamp = nowIso();
+  const runId = `run-missing-upload-e2e-${Date.now()}`;
+  const artifactName = "上一轮需求总结.docx";
+  const taskDir = ensureTaskWorkspace(taskRoot, taskId);
+  const artifactDir = path.join(taskDir, "artifacts", "runs", runId);
+  const assistantMessage =
+    "已继续上一轮总结并生成 Word 的需求。请使用下方下载卡片获取 Word 文件。";
+
+  fs.mkdirSync(artifactDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(artifactDir, artifactName),
+    Buffer.from(`DOCX-STUB:${artifactName}:${runId}`),
+  );
+
+  runSql(`
+UPDATE tasks
+SET status = 'complete',
+    updated_at = ${sqlString(timestamp)},
+    error = NULL,
+    needs_input = NULL,
+    active_run_id = NULL
+WHERE task_id = ${sqlString(taskId)};
+
+INSERT INTO runs (
+  task_id, id, status, message, model, started_at, completed_at,
+  error, needs_input, artifact_base_path, artifact_names
+)
+VALUES (
+  ${sqlString(taskId)},
+  ${sqlString(runId)},
+  'complete',
+  ${sqlString(userMessage)},
+  'deepseek-v4-flash',
+  ${sqlString(timestamp)},
+  ${sqlString(timestamp)},
+  NULL,
+  NULL,
+  ${sqlString(`artifacts/runs/${runId}`)},
+  ${sqlJson([artifactName])}
+);
+
+INSERT INTO messages (task_id, run_id, role, content, created_at, level)
+VALUES
+  (${sqlString(taskId)}, ${sqlString(runId)}, 'user', ${sqlString(userMessage)}, ${sqlString(timestamp)}, NULL),
+  (${sqlString(taskId)}, ${sqlString(runId)}, 'assistant', ${sqlString(assistantMessage)}, ${sqlString(timestamp)}, NULL);
+
+${appendEventSql(taskId, {
+  type: "context_loaded",
+  message: "已载入会话上下文。",
+  createdAt: timestamp,
+  runId,
+  level: "info",
+  payload: {
+    message_count: 2,
+    has_previous_user_intent: true,
+    previous_user_intent: "总结内容并生成 Word",
+  },
+})}
+
+${appendEventSql(taskId, {
+  type: "task_completed",
+  message: "任务已完成。",
+  createdAt: timestamp,
+  runId,
+  level: "success",
+  payload: {
+    previous_status: "running",
+    live: {
+      schema_version: 1,
+      kind: "status",
+      stage: "completed",
+      display_text: "任务已完成",
+      diagnostic_label: "runner.terminal",
+      parameter_items: [{ key: "previous_status", value: "running" }],
+      result_status: "success",
+    },
+  },
+})}
+
+${appendEventSql(taskId, {
+  type: "final_answer",
+  message: "Final answer generated",
+  createdAt: timestamp,
+  runId,
+  level: "success",
+  payload: {
+    content: assistantMessage,
+    live: {
+      schema_version: 1,
+      kind: "answer_status",
+      stage: "completed",
+      display_text: "回答已完成",
+      diagnostic_label: "runner.final_answer",
+      parameter_items: [],
+      result_status: "success",
+    },
+  },
+})}
+`);
+
+  return { artifactName, runId };
+}
+
+function seedMissingArtifactTask(taskId, title) {
+  const timestamp = nowIso();
+  const runId = `run-missing-artifact-e2e-${Date.now()}`;
+  const message = "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。";
+  const needsInput = {
+    message,
+    action_label: "重新生成文件",
+    reason: "artifact_missing",
+    repair_hint: "internal repair hint",
+    missing_artifact_names: ["承诺交付.docx"],
+    missing_deliverables: ["Word"],
+    requested_deliverable_types: ["word"],
+    promoted_artifacts: [],
+  };
+
+  runSql(`
+UPDATE tasks
+SET status = 'needs_input',
+    title = ${sqlString(title)},
+    model = 'deepseek-v4-flash',
+    updated_at = ${sqlString(timestamp)},
+    error = NULL,
+    needs_input = ${sqlJson(needsInput)},
+    active_run_id = NULL
+WHERE task_id = ${sqlString(taskId)};
+
+INSERT INTO runs (
+  task_id, id, status, message, model, started_at, completed_at,
+  error, needs_input, artifact_base_path, artifact_names
+)
+VALUES (
+  ${sqlString(taskId)},
+  ${sqlString(runId)},
+  'needs_input',
+  ${sqlString(title)},
+  'deepseek-v4-flash',
+  ${sqlString(timestamp)},
+  ${sqlString(timestamp)},
+  NULL,
+  ${sqlJson(needsInput)},
+  ${sqlString(`artifacts/runs/${runId}`)},
+  '[]'::jsonb
+);
+
+INSERT INTO messages (task_id, run_id, role, content, created_at, level)
+VALUES
+  (${sqlString(taskId)}, ${sqlString(runId)}, 'user', ${sqlString(title)}, ${sqlString(timestamp)}, NULL),
+  (${sqlString(taskId)}, ${sqlString(runId)}, 'assistant', ${sqlString(message)}, ${sqlString(timestamp)}, 'warning');
+
+${appendEventSql(taskId, {
+  type: "needs_input",
+  message,
+  createdAt: timestamp,
+  runId,
+  level: "warning",
+  payload: {
+    message,
+    action_label: "重新生成文件",
+    live: {
+      schema_version: 1,
+      kind: "status",
+      stage: "needs_input",
+      display_text: "文件未成功生成或未能登记为下载文件",
+      diagnostic_label: "runner.artifact_validation",
+      parameter_items: [],
+      result_status: "warning",
+    },
+  },
+})}
+`);
+
+  return { runId };
+}
+
+function seedRunningTask(taskId, title) {
+  const startedAt = nowIso();
+  const runId = `run-running-clear-e2e-${Date.now()}`;
+
+  runSql(`
+UPDATE tasks
+SET status = 'running',
+    title = ${sqlString(title)},
+    model = 'deepseek-v4-flash',
+    updated_at = ${sqlString(startedAt)},
+    error = NULL,
+    needs_input = NULL,
+    active_run_id = ${sqlString(runId)}
+WHERE task_id = ${sqlString(taskId)};
+
+INSERT INTO runs (
+  task_id, id, status, message, model, started_at, completed_at,
+  error, needs_input, artifact_base_path, artifact_names
+)
+VALUES (
+  ${sqlString(taskId)},
+  ${sqlString(runId)},
+  'running',
+  ${sqlString(title)},
+  'deepseek-v4-flash',
+  ${sqlString(startedAt)},
+  NULL,
+  NULL,
+  NULL,
+  ${sqlString(`artifacts/runs/${runId}`)},
+  '[]'::jsonb
+);
+
+INSERT INTO messages (task_id, run_id, role, content, created_at, level)
+VALUES (${sqlString(taskId)}, ${sqlString(runId)}, 'user', ${sqlString(title)}, ${sqlString(startedAt)}, NULL);
+
+${appendEventSql(taskId, {
+  type: "status",
+  message: "任务正在运行。",
+  createdAt: startedAt,
+  runId,
+  level: "info",
+  payload: {
+    live: {
+      schema_version: 1,
+      kind: "status",
+      stage: "running",
+      display_text: "任务正在运行",
+      diagnostic_label: "runner.terminal",
+      parameter_items: [],
+    },
+  },
+})}
+`);
+
+  return { runId };
+}
+
+function retireRunningTask(taskId, runId) {
+  if (!taskId || !runId) {
+    return;
+  }
+  const timestamp = nowIso();
+  runSql(`
+UPDATE tasks
+SET status = 'cancelled',
+    updated_at = ${sqlString(timestamp)},
+    error = NULL,
+    needs_input = NULL,
+    active_run_id = NULL
+WHERE task_id = ${sqlString(taskId)};
+
+UPDATE runs
+SET status = 'cancelled',
+    completed_at = ${sqlString(timestamp)},
+    error = NULL,
+    needs_input = NULL
+WHERE task_id = ${sqlString(taskId)}
+  AND id = ${sqlString(runId)};
+`);
+}
+
+async function createEmptyTask(request) {
+  const created = await request.post(`${API_URL}/api/tasks`, {
+    headers: authHeaders(),
+    data: { model: "deepseek-v4-flash" },
+  });
+  expect(created.status()).toBe(201);
+  return (await created.json()).task_id;
+}
+
+async function deleteTaskIfPresent(request, taskId) {
+  if (!taskId) {
+    return;
+  }
+  try {
+    await request.delete(`${API_URL}/api/tasks/${encodeURIComponent(taskId)}`, {
+      headers: authHeaders(),
+    });
+  } catch {
+    // The UI clear-all path may have already deleted this task.
+  }
+}
+
+async function expectNoVisibleInternalFields(page) {
+  const visibleText = await page.locator("body").innerText();
+  for (const field of INTERNAL_DELIVERY_FIELDS) {
+    expect(visibleText).not.toContain(field);
+  }
+}
+
+test.use({ acceptDownloads: true, baseURL: BASE_URL, viewport: { width: 1366, height: 820 } });
+
+test("missing upload clarification, file delivery, and clear-all warnings stay user-safe", async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(180_000);
+
+  const taskRoot = requirePath(TASK_ROOT, "MYAGENT_E2E_TASK_ROOT");
+  const evidenceDir = requirePath(EVIDENCE_DIR, "MYAGENT_E2E_EVIDENCE_DIR");
+  fs.mkdirSync(evidenceDir, { recursive: true });
+  const uploadFixture = writeUploadFixture(evidenceDir);
+  const uploadFileName = path.basename(uploadFixture);
+  const runMarker = randomUUID().slice(0, 8);
+  const createdTaskIds = new Set();
+  const consoleErrors = [];
+  let missingUploadTaskId = "";
+  let runningTaskId = "";
+  let runningRunId = "";
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  try {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: /新建会话/ })).toBeVisible();
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "01-empty-workspace.png"),
+    });
+
+    await page.locator("textarea.promptTextarea").fill("总结内容并生成 Word");
+    const missingUploadResponsePromise = page.waitForResponse((response) => {
+      const url = response.url();
+      return (
+        response.request().method() === "POST" &&
+        url.startsWith(`${API_URL}/api/tasks/`) &&
+        url.endsWith("/messages")
+      );
+    });
+    await page.getByRole("button", { name: "发送" }).click();
+    const missingUploadResponse = await missingUploadResponsePromise;
+    expect(missingUploadResponse.ok()).toBeTruthy();
+    const missingUploadState = await missingUploadResponse.json();
+    missingUploadTaskId = missingUploadState.task_id;
+    createdTaskIds.add(missingUploadTaskId);
+
+    await expect(page.getByText(/你是不是忘记上传文件了/)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/上传后我继续帮你生成 Word/)).toBeVisible();
+    await expect(page.getByText("配置提醒")).toHaveCount(0);
+    await expect(page.getByText("等待补充输入")).toHaveCount(0);
+    await expect(page.getByText("reason")).toHaveCount(0);
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "02-missing-upload-clarification.png"),
+    });
+
+    let capturedFollowUp = "";
+    await page.route(/\/api\/tasks\/[^/]+\/messages$/, async (route) => {
+      const routeUrl = new URL(route.request().url());
+      const routeTaskId = decodeURIComponent(routeUrl.pathname.split("/")[3] || "");
+      if (routeTaskId !== missingUploadTaskId) {
+        await route.continue();
+        return;
+      }
+
+      const body = JSON.parse(route.request().postData() || "{}");
+      capturedFollowUp = String(body.message || body.content || "");
+      expect(capturedFollowUp).toContain("继续上一轮需求");
+      expect(capturedFollowUp).toContain("总结内容并生成 Word");
+      expect(capturedFollowUp).toContain(uploadFileName);
+
+      const seeded = seedContinuationDocxRun(taskRoot, routeTaskId, capturedFollowUp);
+      const stateResponse = await request.get(
+        `${API_URL}/api/tasks/${encodeURIComponent(routeTaskId)}`,
+        { headers: authHeaders() },
+      );
+      expect(stateResponse.ok()).toBeTruthy();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(await stateResponse.json()),
+      });
+      fs.writeFileSync(
+        path.join(evidenceDir, "file-only-follow-up.json"),
+        `${JSON.stringify({ message: capturedFollowUp, ...seeded }, null, 2)}\n`,
+        "utf8",
+      );
+    });
+
+    await page.locator("#document-files").setInputFiles(uploadFixture);
+    await expect(page.getByTestId("selected-file-card")).toContainText(uploadFileName);
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "03-file-only-selected.png"),
+    });
+
+    await expect(page.getByRole("button", { name: "发送" })).toBeEnabled();
+    await page.getByRole("button", { name: "发送" }).click();
+    await expect(page.locator(".userMessageFileList", { hasText: uploadFileName })).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByText("已继续上一轮总结并生成 Word 的需求")).toBeVisible();
+    await expect(page.getByText("上一轮需求总结.docx", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "下载 上一轮需求总结.docx" })).toBeVisible();
+    await expect(page.getByText("文件未成功生成或未能登记为下载文件")).toHaveCount(0);
+    await expect(page.getByText("配置提醒")).toHaveCount(0);
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "04-file-only-continued-docx-card.png"),
+    });
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "下载 上一轮需求总结.docx" }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toBe("上一轮需求总结.docx");
+    await download.saveAs(path.join(evidenceDir, download.suggestedFilename()));
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "05-docx-download-finished.png"),
+    });
+
+    const missingArtifactTaskId = await createEmptyTask(request);
+    createdTaskIds.add(missingArtifactTaskId);
+    const missingArtifactTitle = `友好交付失败-${runMarker}`;
+    const missingArtifactSeed = seedMissingArtifactTask(missingArtifactTaskId, missingArtifactTitle);
+
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: missingArtifactTitle, exact: true })).toBeVisible();
+    await page.getByRole("button", { name: missingArtifactTitle, exact: true }).click();
+    await expect(page.locator(".historyItemShell-active", { hasText: missingArtifactTitle })).toBeVisible();
+    await expect(page.getByText("文件未成功生成或未能登记为下载文件").first()).toBeVisible();
+    await expect(page.getByText("重新生成文件").first()).toBeVisible();
+    await expect(page.getByText("配置提醒")).toHaveCount(0);
+    await expectNoVisibleInternalFields(page);
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "06-friendly-missing-artifact.png"),
+    });
+
+    page.once("dialog", async (dialog) => {
+      expect(dialog.message()).toContain("清空所有历史会话");
+      await dialog.accept();
+    });
+    await page.getByRole("button", { name: "清空所有会话" }).click();
+    await expect(page.getByRole("button", { name: missingArtifactTitle, exact: true })).toHaveCount(0);
+    const clearedResponse = await request.get(
+      `${API_URL}/api/tasks/${encodeURIComponent(missingArtifactTaskId)}`,
+      { headers: authHeaders() },
+    );
+    expect(clearedResponse.status()).toBe(404);
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "07-needs-input-cleared.png"),
+    });
+
+    runningTaskId = await createEmptyTask(request);
+    createdTaskIds.add(runningTaskId);
+    const runningTitle = `运行中阻止清空-${runMarker}`;
+    const runningSeed = seedRunningTask(runningTaskId, runningTitle);
+    runningRunId = runningSeed.runId;
+
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: runningTitle, exact: true })).toBeVisible();
+    let unexpectedDialog = false;
+    page.once("dialog", async (dialog) => {
+      unexpectedDialog = true;
+      await dialog.dismiss();
+    });
+    await page.getByRole("button", { name: "清空所有会话" }).click();
+    await expect(page.getByText("有任务正在运行，完成或停止后再清空历史会话。")).toBeVisible();
+    expect(unexpectedDialog).toBe(false);
+    await expect(page.getByRole("button", { name: runningTitle, exact: true })).toBeVisible();
+    const runningResponse = await request.get(
+      `${API_URL}/api/tasks/${encodeURIComponent(runningTaskId)}`,
+      { headers: authHeaders() },
+    );
+    expect(runningResponse.ok()).toBeTruthy();
+    expect((await runningResponse.json()).status).toBe("running");
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(evidenceDir, "08-running-blocks-clear-all.png"),
+    });
+
+    expect(consoleErrors).toEqual([]);
+    fs.writeFileSync(
+      path.join(evidenceDir, "assertions.json"),
+      `${JSON.stringify(
+        {
+          consoleErrors,
+          capturedFollowUp,
+          missingArtifactRunId: missingArtifactSeed.runId,
+          runningRunId,
+          tasks: {
+            missingUploadTaskId,
+            runningTaskId,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  } finally {
+    if (runningTaskId && runningRunId) {
+      retireRunningTask(runningTaskId, runningRunId);
+    }
+    for (const taskId of createdTaskIds) {
+      await deleteTaskIfPresent(request, taskId);
+    }
+  }
+});

--- a/frontend/hooks/use-task-workspace.ts
+++ b/frontend/hooks/use-task-workspace.ts
@@ -224,6 +224,10 @@ export function buildFileOnlyFollowUpMessage(
   return `我已上传文件，请读取并处理本轮上传资源。${fileSummary}`;
 }
 
+export function hasActiveTaskSummary(summaries: readonly Pick<TaskSummary, "status">[]) {
+  return summaries.some((summary) => isTaskActive(summary.status));
+}
+
 export function useTaskWorkspace() {
   const [taskId, setTaskId] = useState<string>("");
   const [status, setStatus] = useState<TaskStatus>("idle");
@@ -783,7 +787,7 @@ export function useTaskWorkspace() {
         return;
       }
       const summary = taskSummaries.find((item) => item.id === id);
-      if (summary?.status === "running") {
+      if (summary && isTaskActive(summary.status)) {
         setErrorLevel("warning");
         setError("任务运行中，暂时不能删除。");
         return;
@@ -826,7 +830,7 @@ export function useTaskWorkspace() {
     ) {
       return;
     }
-    if (activeTask || taskSummaries.some((summary) => isTaskActive(summary.status))) {
+    if (activeTask || hasActiveTaskSummary(taskSummaries)) {
       setErrorLevel("warning");
       setError("有任务正在运行，完成或停止后再清空历史会话。");
       return;

--- a/frontend/hooks/use-task-workspace.ts
+++ b/frontend/hooks/use-task-workspace.ts
@@ -64,7 +64,9 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   },
 ];
 
-const DEFAULT_FILE_PROMPT = "请分析已上传文件，先按需读取资源内容，再总结关键差异。";
+const FILE_ONLY_FOLLOW_UP_INTENT_MAX_CHARS = 240;
+const FILE_ONLY_FOLLOW_UP_FILE_MAX_COUNT = 6;
+const FILE_ONLY_FOLLOW_UP_PREFIX = "我已上传文件，请继续上一轮需求";
 export const MAX_SSE_RETRIES = 5;
 export const ARTIFACT_OBJECT_URL_REVOKE_DELAY_MS = 60_000;
 export const TASK_WORKSPACE_STREAM_EVENT_TYPES = new Set([
@@ -169,6 +171,57 @@ export function buildRunLogDownloadName(runId: string) {
     .replace(/[^a-zA-Z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return `${normalizedRunId || "run"}-logs.jsonl`;
+}
+
+function normalizeFollowUpText(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripSentenceEnding(value: string) {
+  return value.replace(/[。.!！?？]+$/g, "").trim();
+}
+
+function truncatePreviousIntent(value: string) {
+  const normalized = stripSentenceEnding(normalizeFollowUpText(value));
+  if (normalized.length <= FILE_ONLY_FOLLOW_UP_INTENT_MAX_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, FILE_ONLY_FOLLOW_UP_INTENT_MAX_CHARS - 3).trimEnd()}...`;
+}
+
+function previousUserIntent(messages: readonly Pick<ChatMessage, "role" | "content">[]) {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role !== "user") {
+      continue;
+    }
+    const content = normalizeFollowUpText(message.content);
+    if (!content || content.startsWith(FILE_ONLY_FOLLOW_UP_PREFIX)) {
+      continue;
+    }
+    return truncatePreviousIntent(content);
+  }
+  return "";
+}
+
+export function buildFileOnlyFollowUpMessage(
+  files: readonly { name?: string }[],
+  messages: readonly Pick<ChatMessage, "role" | "content">[] = [],
+) {
+  const fileNames = files
+    .map((file) => normalizeFollowUpText(file.name ?? ""))
+    .filter(Boolean);
+  const visibleFileNames = fileNames.slice(0, FILE_ONLY_FOLLOW_UP_FILE_MAX_COUNT);
+  const extraFileCount = fileNames.length - visibleFileNames.length;
+  const fileSummary =
+    visibleFileNames.length > 0
+      ? `本轮文件：${visibleFileNames.join("、")}${extraFileCount > 0 ? ` 等 ${fileNames.length} 个文件` : ""}。`
+      : "本轮已上传文件。";
+  const intent = previousUserIntent(messages);
+  if (intent) {
+    return `${FILE_ONLY_FOLLOW_UP_PREFIX}：${intent}。${fileSummary}`;
+  }
+  return `我已上传文件，请读取并处理本轮上传资源。${fileSummary}`;
 }
 
 export function useTaskWorkspace() {
@@ -504,8 +557,8 @@ export function useTaskWorkspace() {
     }
     setIsSubmittingTask(true);
     const content = input.trim();
-    const taskContent = content || DEFAULT_FILE_PROMPT;
     const files = selectedFiles;
+    const taskContent = content || buildFileOnlyFollowUpMessage(files, messages);
     let requestTaskId = taskId;
 
     try {
@@ -539,6 +592,7 @@ export function useTaskWorkspace() {
     input,
     isSubmittingTask,
     isSwitchingConversation,
+    messages,
     model,
     refreshTask,
     refreshTaskSummaries,

--- a/frontend/tests/state/test_task_state.test.ts
+++ b/frontend/tests/state/test_task_state.test.ts
@@ -1299,6 +1299,47 @@ test("formatNeedsInput localizes fixed payload keys and fallback messages", () =
   );
 });
 
+test("formatNeedsInput hides internal deliverable failure fields from legacy payloads", () => {
+  const state = normalizeTaskState(
+    {
+      task_id: "task-1",
+      status: "needs_input",
+      needs_input: {
+        message: "文件未生成或未登记为产物，请修复后重新生成。",
+        reason: "deliverable_artifact_missing",
+        repair_hint: "请在当前任务工作区生成文件并登记为 artifact 后重试。",
+        missing_artifact_names: ["summary.docx"],
+        missing_deliverables: ["要求的交付类型缺失：Word"],
+        requested_deliverable_types: ["Word"],
+        promoted_artifacts: [],
+        action_label: "重新生成文件",
+      },
+    },
+    "fallback",
+  );
+
+  assert.deepEqual(state.needsInput, {
+    message: "文件未生成或未登记为产物，请修复后重新生成。",
+    action_label: "重新生成文件",
+  });
+  const content = formatNeedsInput(state.needsInput ?? {});
+
+  assert.equal(
+    content,
+    "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。 建议操作：重新生成文件",
+  );
+  for (const internalField of [
+    "reason",
+    "repair_hint",
+    "missing_artifact_names",
+    "missing_deliverables",
+    "requested_deliverable_types",
+    "promoted_artifacts",
+  ]) {
+    assert.equal(content.includes(internalField), false);
+  }
+});
+
 test("normalizeTaskSummaries reads backend history titles without subtitles", () => {
   const summaries = normalizeTaskSummaries([
     {

--- a/frontend/tests/state/test_task_state.test.ts
+++ b/frontend/tests/state/test_task_state.test.ts
@@ -375,6 +375,26 @@ test("normalizeTaskState extracts file-only user message file names", () => {
   assert.equal(state.messages[0].content.includes("总结内容并生成 Word"), true);
 });
 
+test("normalizeTaskState treats continuation upload follow-up as file-only", () => {
+  const state = normalizeTaskState(
+    {
+      task_id: "task-1",
+      status: "complete",
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          content: "我已上传文件，请继续上一轮需求：总结内容并生成 Word。本轮文件：clarification-brief.txt。",
+        },
+      ],
+    },
+    "fallback",
+  );
+
+  assert.equal(state.messages[0].fileOnly, true);
+  assert.deepEqual(state.messages[0].files, [{ name: "clarification-brief.txt" }]);
+});
+
 test("normalizeTaskState preserves explicit user message file metadata safely", () => {
   const state = normalizeTaskState(
     {

--- a/frontend/tests/state/test_task_state.test.ts
+++ b/frontend/tests/state/test_task_state.test.ts
@@ -280,13 +280,28 @@ test("user message cards expose a copy action for the exact message content", ()
   const userCopyIndex = conversationSource.indexOf("className={userCopyButtonClassName}");
 
   assert.equal(conversationSource.includes("复制用户消息"), true);
-  assert.equal(conversationSource.includes("onCopyText(message.content, undefined"), true);
+  assert.equal(conversationSource.includes("onCopyText(userCopyText, undefined"), true);
   assert.equal(conversationSource.includes("onCopyText(formatTime"), false);
   assert.equal(conversationSource.includes("已复制用户消息"), true);
   assert.equal(conversationSource.includes("copyButton-copied"), true);
   assert.equal(userTimeIndex >= 0, true);
   assert.equal(userCopyIndex >= 0, true);
   assert.equal(userTimeIndex < userCopyIndex, true);
+});
+
+test("user file-only messages render compact uploaded file chips", () => {
+  const conversationSource = readFileSync(
+    new URL("../../components/chat/TaskConversation.tsx", import.meta.url),
+    "utf-8",
+  );
+  const cssSource = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf-8");
+
+  assert.equal(conversationSource.includes("message.fileOnly ? \"\" : message.content"), true);
+  assert.equal(conversationSource.includes("userMessageFileList"), true);
+  assert.equal(conversationSource.includes("userMessageFileChip"), true);
+  assert.equal(conversationSource.includes("title={file.name}"), true);
+  assert.match(cssSource, /\.userMessageFileName\s*\{[\s\S]*?text-overflow: ellipsis;[\s\S]*?white-space: nowrap;/);
+  assert.match(cssSource, /@media \(max-width: 520px\)[\s\S]*?\.userMessageFileChip\s*\{[\s\S]*?max-width: 100%;/);
 });
 
 test("normalizeTaskState preserves user message content without display localization", () => {
@@ -318,6 +333,50 @@ test("normalizeTaskState preserves user message content without display localiza
   assert.equal(state.messages[0].content, "  Task completed\n原样复制  ");
   assert.equal(state.messages[1].content, "Uploaded input.json");
   assert.equal(state.messages[2].content, "任务已完成。");
+});
+
+test("normalizeTaskState extracts file-only user message file names", () => {
+  const longFileName = "这是一份用于验证窄屏不会撑破消息卡片的超长文件名.docx";
+  const state = normalizeTaskState(
+    {
+      task_id: "task-1",
+      status: "complete",
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          content: `请继续上一轮需求：总结内容并生成 Word。本轮文件：${longFileName}、报价表.xlsx。`,
+        },
+      ],
+    },
+    "fallback",
+  );
+
+  assert.equal(state.messages[0].fileOnly, true);
+  assert.deepEqual(state.messages[0].files, [{ name: longFileName }, { name: "报价表.xlsx" }]);
+  assert.equal(state.messages[0].content.includes("总结内容并生成 Word"), true);
+});
+
+test("normalizeTaskState preserves explicit user message file metadata safely", () => {
+  const state = normalizeTaskState(
+    {
+      task_id: "task-1",
+      status: "complete",
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          content: "",
+          files: [{ name: "source.md" }, { filename: "方案.docx" }, { name: "source.md" }],
+        },
+      ],
+    },
+    "fallback",
+  );
+
+  assert.deepEqual(state.messages[0].files, [{ name: "source.md" }, { name: "方案.docx" }]);
+  assert.equal(state.messages[0].fileOnly, undefined);
+  assert.equal(state.messages[0].content, "");
 });
 
 test("normalizeTaskState preserves event seq and thinking stream diagnostics", () => {

--- a/frontend/tests/state/test_task_state.test.ts
+++ b/frontend/tests/state/test_task_state.test.ts
@@ -18,6 +18,7 @@ import {
   normalizeTaskSummaries,
   normalizeTaskState,
   resolveApiBaseUrl,
+  type TaskStatus,
   type TaskState,
 } from "../../app/task-state";
 
@@ -50,6 +51,23 @@ test("normalizeTaskState preserves interrupted as an inactive known status", () 
   assert.equal(state.status, "interrupted");
   assert.equal(state.statusLabel, "interrupted");
   assert.equal(isTaskActive(state.status), false);
+});
+
+test("isTaskActive treats only running as active", () => {
+  const inactiveStatuses: TaskStatus[] = [
+    "idle",
+    "complete",
+    "failed",
+    "cancelled",
+    "needs_input",
+    "interrupted",
+    "unknown",
+  ];
+
+  assert.equal(isTaskActive("running"), true);
+  for (const status of inactiveStatuses) {
+    assert.equal(isTaskActive(status), false);
+  }
 });
 
 test("mergeExecutionLogs appends only new events by id", () => {

--- a/frontend/tests/workspace/test_task_workspace.test.ts
+++ b/frontend/tests/workspace/test_task_workspace.test.ts
@@ -81,6 +81,25 @@ void describe("use-task-workspace exports", () => {
     assert.doesNotMatch(message, /继续上一轮需求/);
   });
 
+  void it("should treat needs-input summaries as inactive for history clearing", async () => {
+    const mod = await import("../../hooks/use-task-workspace");
+
+    assert.strictEqual(
+      mod.hasActiveTaskSummary([
+        { status: "complete" },
+        { status: "failed" },
+        { status: "cancelled" },
+        { status: "needs_input" },
+        { status: "interrupted" },
+      ]),
+      false,
+    );
+    assert.strictEqual(
+      mod.hasActiveTaskSummary([{ status: "needs_input" }, { status: "running" }]),
+      true,
+    );
+  });
+
   void it("should not top-level navigate opened artifact windows to blob URLs", () => {
     const source = readFileSync(
       new URL("../../hooks/use-task-workspace.ts", import.meta.url),
@@ -367,7 +386,8 @@ void describe("use-task-workspace exports", () => {
     );
 
     assert.strictEqual(hookSource.includes("const handleClearConversations = useCallback"), true);
-    assert.strictEqual(hookSource.includes("taskSummaries.some((summary) => isTaskActive(summary.status))"), true);
+    assert.strictEqual(hookSource.includes("hasActiveTaskSummary(taskSummaries)"), true);
+    assert.strictEqual(hookSource.includes("if (summary && isTaskActive(summary.status))"), true);
     assert.strictEqual(hookSource.includes("清空所有历史会话后无法恢复"), true);
     assert.strictEqual(hookSource.includes("for (const id of deletedIds)"), true);
     assert.strictEqual(workspaceSource.includes("onClearConversations={workspace.handleClearConversations}"), true);

--- a/frontend/tests/workspace/test_task_workspace.test.ts
+++ b/frontend/tests/workspace/test_task_workspace.test.ts
@@ -56,6 +56,31 @@ void describe("use-task-workspace exports", () => {
     assert.strictEqual(mod.buildRunLogDownloadName(""), "run-logs.jsonl");
   });
 
+  void it("should make file-only sends continue the previous user intent", async () => {
+    const mod = await import("../../hooks/use-task-workspace");
+    const message = mod.buildFileOnlyFollowUpMessage(
+      [{ name: "需求说明.docx" }, { name: "报价表.xlsx" }],
+      [
+        { role: "user", content: "总结内容并生成 Word" },
+        { role: "assistant", content: "你是不是忘记上传文件了？上传后我继续帮你生成 Word。" },
+      ],
+    );
+
+    assert.match(message, /请继续上一轮需求/);
+    assert.match(message, /总结内容并生成 Word/);
+    assert.match(message, /需求说明\.docx/);
+    assert.match(message, /报价表\.xlsx/);
+  });
+
+  void it("should use a resource-focused prompt for initial file-only sends", async () => {
+    const mod = await import("../../hooks/use-task-workspace");
+    const message = mod.buildFileOnlyFollowUpMessage([{ name: "source.md" }], []);
+
+    assert.match(message, /请读取并处理本轮上传资源/);
+    assert.match(message, /source\.md/);
+    assert.doesNotMatch(message, /继续上一轮需求/);
+  });
+
   void it("should not top-level navigate opened artifact windows to blob URLs", () => {
     const source = readFileSync(
       new URL("../../hooks/use-task-workspace.ts", import.meta.url),
@@ -146,8 +171,31 @@ void describe("use-task-workspace exports", () => {
       submitSource.includes("postTaskMessage(id, taskContent, model, selectedSkillNames)"),
       true,
     );
+    assert.strictEqual(
+      submitSource.includes("const taskContent = content || buildFileOnlyFollowUpMessage(files, messages);"),
+      true,
+    );
     assert.ok(trySource.indexOf("postTaskMessage") < trySource.indexOf("setSelectedSkills([])"));
     assert.strictEqual(catchSource.includes("setSelectedSkills([])"), false);
+  });
+
+  void it("should upload files before file-only follow-up and refresh after send failures", () => {
+    const source = readFileSync(
+      new URL("../../hooks/use-task-workspace.ts", import.meta.url),
+      "utf-8",
+    );
+    const submitStart = source.indexOf("const handleSubmit = useCallback");
+    const submitEnd = source.indexOf("const handleSelectSkill = useCallback");
+    const submitSource = source.slice(submitStart, submitEnd);
+    const trySource = submitSource.slice(
+      submitSource.indexOf("try {"),
+      submitSource.indexOf("} catch (caught)"),
+    );
+    const catchSource = submitSource.slice(submitSource.indexOf("} catch (caught)"));
+
+    assert.ok(trySource.indexOf("await uploadTaskFiles(id, files);") < trySource.indexOf("await postTaskMessage"));
+    assert.ok(catchSource.indexOf("if (requestTaskId)") < catchSource.indexOf("await refreshTask(requestTaskId);"));
+    assert.strictEqual(catchSource.includes("setSelectedFiles([])"), false);
   });
 
   void it("should expose skill state and handlers across the workspace source boundary", () => {

--- a/frontend/tests/workspace/test_workspace_view.test.ts
+++ b/frontend/tests/workspace/test_workspace_view.test.ts
@@ -1600,7 +1600,7 @@ test("buildStateNoticeMessages renders state notices as assistant messages", () 
       id: "state:needs-input",
       role: "assistant",
       content: "需要补充字段",
-      level: "warning",
+      level: "error",
     },
   ]);
   assert.deepEqual(buildStateNoticeMessages("", "   "), []);
@@ -2574,6 +2574,24 @@ test("message panel helpers map assistant notices to TenderWord-like card states
   assert.equal(getMessagePanelTone(warningMessage), "warning");
   assert.equal(formatMessagePanelStatus(warningMessage), "配置提醒");
   assert.equal(formatMessagePanelTitle(warningMessage), "AI 生成内容");
+  assert.equal(
+    getMessagePanelTone({
+      id: "m2-deliverable",
+      role: "assistant",
+      content: "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。",
+      level: "warning",
+    }),
+    "error",
+  );
+  assert.equal(
+    formatMessagePanelStatus({
+      id: "m2-deliverable",
+      role: "assistant",
+      content: "文件未成功生成或未能登记为下载文件。请重新生成交付文件后再试。",
+      level: "warning",
+    }),
+    "生成失败",
+  );
   assert.equal(getMessagePanelTone(systemMessage), "system");
   assert.equal(formatMessagePanelStatus(systemMessage), "系统消息");
   assert.equal(formatMessagePanelTitle(systemMessage), "系统消息");

--- a/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
@@ -140,7 +140,7 @@
         "Tests pass"
       ],
       "priority": 7,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false

--- a/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
@@ -36,7 +36,7 @@
         "Tests pass"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false

--- a/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
@@ -96,7 +96,7 @@
         "Tests pass"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false

--- a/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
@@ -117,7 +117,7 @@
         "Tests pass"
       ],
       "priority": 6,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false

--- a/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
@@ -162,7 +162,7 @@
         "Tests pass"
       ],
       "priority": 8,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false

--- a/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
@@ -16,7 +16,7 @@
         "Tests pass"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false

--- a/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/prd.json
@@ -55,7 +55,7 @@
         "Tests pass"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false
@@ -75,7 +75,7 @@
         "Tests pass"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": "",
       "retryCount": 0,
       "blocked": false

--- a/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
@@ -11,6 +11,7 @@ Source: prd.json
 - 发送消息允许从 `needs_input` 继续：`backend/app/api/tasks.py:170` 的 `expected_statuses` 包含 `needs_input`。
 - 交付保护集中在 `backend/app/runner/core.py:524` 的 `_ensure_run_deliverables()`，当前 payload 暴露内部字段，需要收敛用户可见字段。
 - 前端 active 状态口径集中在 `frontend/app/task-state.ts:1349`，当前只把 `running` 视为 active，应补测试锁定。
+- 前端历史删除/清空的运行中拦截应复用 `isTaskActive()` 或 `hasActiveTaskSummary()`，不要把 `needs_input`、`interrupted` 等终态当作 active。
 - needs-input notice 当前在 `frontend/app/workspace-view.ts:122` 作为 warning 输出，并在 `frontend/app/workspace-view.ts:1662` 显示为“配置提醒”，需要调整或过滤。
 - 文件-only submit 在 `frontend/hooks/use-task-workspace.ts` 中用 `buildFileOnlyFollowUpMessage()` 构造非空 follow-up；有历史用户意图时显式写“继续上一轮需求”，后端 `MessageRequest.message` 仍保持非空合同。
 - 文件-only 用户消息展示由 `frontend/app/task-state.ts` 提取安全文件名元数据到 `ChatMessage.files`/`fileOnly`，`TaskConversation` 可隐藏生成式 follow-up 文案但保留原始 `content` 供复制和上下文使用。
@@ -74,4 +75,16 @@ Source: prd.json
   - `_ensure_run_deliverables()` 的返回值会直接进入 task/run `needs_input` 和 `needs_input` event payload，不能在这里放用户不应看到的诊断字段。
   - 旧会话 payload 可能仍包含内部字段；前端展示前需要在标准化和 `formatNeedsInput()` 两层过滤，避免状态 notice 或历史数据泄漏字段名。
   - 交付失败不能用 warning 消息卡片，否则标题会变成“配置提醒”；已知交付失败内容应走 error tone，显示“生成失败”。
+---
+
+## 2026-05-25 01:25 - US-006
+- 锁定了 `needs_input` 的非运行状态口径：后端删除 API 允许 `complete`、`failed`、`cancelled`、`needs_input`、`interrupted` 删除，只在 task 状态为 `running` 或 runner active 时返回 409。
+- 前端新增 `hasActiveTaskSummary()` 并让删除/清空历史复用 `isTaskActive()`，确保清空所有会话只被真实 running summary 或当前 running task 拦截。
+- 更改的文件：`backend/tests/unit/api/test_tasks.py`、`frontend/hooks/use-task-workspace.ts`、`frontend/tests/state/test_task_state.test.ts`、`frontend/tests/workspace/test_task_workspace.test.ts`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd backend && uv run pytest tests/unit/api/test_tasks.py -q`；`cd frontend && npm test -- tests/workspace/test_task_workspace.test.ts tests/workspace/test_workspace_view.test.ts`；`cd frontend && npm test -- tests/state/test_task_state.test.ts`；`cd frontend && npm run typecheck`；`cd frontend && npm run lint`；`cd backend && uv run ruff check .`；`cd backend && uv run mypy app tests`；`git diff --check`
+- 浏览器验证：未执行真实浏览器 E2E；本轮只处理 US-006 的删除/清空状态规则，完整真实浏览器路径和截图证据留给 US-007。
+- **未来迭代的学习：**
+  - 后端删除会话必须同时检查持久状态和 `runner.is_running(task_id)`，防止状态尚未刷新时误删 active run。
+  - `needs_input` 是可继续、可删除、可清空的非运行终态；前端如需判断历史中是否有活跃任务，应统一走 `isTaskActive()`。
+  - 清空历史的前端单测更适合锁定纯 helper 和 hook source boundary；真实浏览器“清空所有会话”路径由 US-007 覆盖。
 ---

--- a/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
@@ -13,6 +13,8 @@ Source: prd.json
 - 前端 active 状态口径集中在 `frontend/app/task-state.ts:1349`，当前只把 `running` 视为 active，应补测试锁定。
 - needs-input notice 当前在 `frontend/app/workspace-view.ts:122` 作为 warning 输出，并在 `frontend/app/workspace-view.ts:1662` 显示为“配置提醒”，需要调整或过滤。
 - 文件-only submit 在 `frontend/hooks/use-task-workspace.ts` 中用 `buildFileOnlyFollowUpMessage()` 构造非空 follow-up；有历史用户意图时显式写“继续上一轮需求”，后端 `MessageRequest.message` 仍保持非空合同。
+- 文件-only 用户消息展示由 `frontend/app/task-state.ts` 提取安全文件名元数据到 `ChatMessage.files`/`fileOnly`，`TaskConversation` 可隐藏生成式 follow-up 文案但保留原始 `content` 供复制和上下文使用。
+- 交付成功判断以当前 run 的 `artifact_names` 后缀满足请求类型为准；请求类型已满足时不要再用 final answer 中的具体文件名做失败判定。
 
 ## 2026-05-24 23:14 - US-001
 - 实现了缺上传/缺正文时的普通 AI 澄清：runner 在启动 agent 前识别“总结/生成交付物但没有上传、内联正文或可复用上下文”的请求，直接写入 assistant 澄清并以 success final_answer 完成 run，不再产生 `needs_input` warning。
@@ -35,4 +37,28 @@ Source: prd.json
   - 前端文件-only 发送不能提交空 message，因为后端 `MessageRequest.message` 有 `min_length=1`；应在 hook 层生成清晰 follow-up。
   - 会话连续性由 `ConversationContextBuilder` 回放上一轮消息，上传文件内容由 runner 的资源 manifest 和资源工具提供，不应写入普通 message。
   - `uploadTaskFiles()` 成功但 `postTaskMessage()` 失败时要保留用户可见上传状态，catch 分支的 `refreshTask(requestTaskId)` 是必要兜底。
+---
+
+## 2026-05-25 00:15 - US-003
+- 实现了文件-only 用户消息渲染：前端标准化层从生成式 follow-up 或显式 message 文件元数据中提取安全文件名，用户消息气泡渲染紧凑文件 chip。
+- 隐藏文件-only 消息的生成式 follow-up 文案，但保留原始 `message.content` 用于复制按钮和后端上下文；空文本但有文件元数据时复制按钮回退复制文件名列表。
+- 补齐窄屏和长文件名样式约束：文件 chip 在用户气泡内省略长文件名，520px 以下占满可用宽度，不撑破消息卡片。
+- 更改的文件：`frontend/app/task-state.ts`、`frontend/components/chat/TaskConversation.tsx`、`frontend/app/globals.css`、`frontend/tests/state/test_task_state.test.ts`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd frontend && npm test -- tests/state/test_task_state.test.ts tests/workspace/test_workspace_view.test.ts tests/workspace/test_task_workspace.test.ts`；`cd frontend && npm run typecheck`；`cd frontend && npm run lint`；`git diff --check`
+- 浏览器验证：未执行完整浏览器路径；`3001` 前端可访问，但 `8001` 后端不可连接，且本轮只处理 US-003，真实浏览器 E2E 留给 US-007。
+- **未来迭代的学习：**
+  - `ChatMessage.content` 仍是后端上下文和复制的权威文本；展示层如果要压缩文件-only prompt，应通过 `fileOnly`/`files` 投影处理，不要改写原始 content。
+  - 从 `buildFileOnlyFollowUpMessage()` 文案解析文件名时不能把扩展名中的 `.` 当句末截断。
+  - 用户消息内的文件 chip 需要 `min-width: 0`、`max-width` 和 `text-overflow: ellipsis` 同时存在，窄屏下再把 chip 设为 100% 宽。
+---
+
+## 2026-05-25 00:32 - US-004
+- 实现了交付成功按可下载产物类型判定：Word/PPT/Excel/报告请求只要当前 run 存在匹配后缀的 artifact，就不再因 final answer 中声称文件名不一致而进入缺文件保护。
+- 补齐后端回归测试，覆盖 `.docx`、`.pptx`、`.xlsx`、`.xlsm`、`.html`、`.md`、`.pdf` 满足对应请求类型。
+- 更改的文件：`backend/app/runner/core.py`、`backend/tests/unit/runner/test_core.py`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd backend && uv run pytest tests/unit/runner/test_core.py tests/unit/api/test_artifacts.py -q`；`cd backend && uv run ruff check .`；`cd backend && uv run mypy app tests`；`git diff --check`
+- **未来迭代的学习：**
+  - `_ensure_run_deliverables()` 中 `run.artifact_names` 是本轮交付成功判断的权威来源，final answer 文件名只能作为没有请求类型时的兜底保护线索。
+  - Excel 请求同时接受 `.xlsx` 和 `.xlsm`，报告请求接受 `.html`、`.md` 和 `.pdf`。
+  - 交付保护测试要给请求提供足够内联材料或上传资源，否则会先触发缺来源澄清。
 ---

--- a/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
@@ -15,6 +15,7 @@ Source: prd.json
 - 文件-only submit 在 `frontend/hooks/use-task-workspace.ts` 中用 `buildFileOnlyFollowUpMessage()` 构造非空 follow-up；有历史用户意图时显式写“继续上一轮需求”，后端 `MessageRequest.message` 仍保持非空合同。
 - 文件-only 用户消息展示由 `frontend/app/task-state.ts` 提取安全文件名元数据到 `ChatMessage.files`/`fileOnly`，`TaskConversation` 可隐藏生成式 follow-up 文案但保留原始 `content` 供复制和上下文使用。
 - 交付成功判断以当前 run 的 `artifact_names` 后缀满足请求类型为准；请求类型已满足时不要再用 final answer 中的具体文件名做失败判定。
+- 交付失败的 `needs_input` payload 对用户可见时只保留 `message`/`action_label`；历史内部字段在 `frontend/app/task-state.ts` 的 needs-input 标准化和格式化中统一过滤。
 
 ## 2026-05-24 23:14 - US-001
 - 实现了缺上传/缺正文时的普通 AI 澄清：runner 在启动 agent 前识别“总结/生成交付物但没有上传、内联正文或可复用上下文”的请求，直接写入 assistant 澄清并以 success final_answer 完成 run，不再产生 `needs_input` warning。
@@ -61,4 +62,16 @@ Source: prd.json
   - `_ensure_run_deliverables()` 中 `run.artifact_names` 是本轮交付成功判断的权威来源，final answer 文件名只能作为没有请求类型时的兜底保护线索。
   - Excel 请求同时接受 `.xlsx` 和 `.xlsm`，报告请求接受 `.html`、`.md` 和 `.pdf`。
   - 交付保护测试要给请求提供足够内联材料或上传资源，否则会先触发缺来源澄清。
+---
+
+## 2026-05-25 01:05 - US-005
+- 收敛了交付失败的用户可见 payload：后端仍将真实缺 artifact 的 run/task 置为 `needs_input`，但 state/event payload 只返回简短 `message` 和安全 `action_label`。
+- 前端对历史旧 `needs_input` payload 过滤 `reason`、`repair_hint`、`missing_artifact_names`、`missing_deliverables`、`requested_deliverable_types`、`promoted_artifacts` 等内部字段，并把交付失败消息渲染为生成失败而非“配置提醒”。
+- 更改的文件：`backend/app/runner/core.py`、`backend/tests/unit/runner/test_core.py`、`frontend/app/task-state.ts`、`frontend/app/workspace-view.ts`、`frontend/tests/state/test_task_state.test.ts`、`frontend/tests/workspace/test_workspace_view.test.ts`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd backend && uv run pytest tests/unit/runner/test_core.py -q`；`cd frontend && npm test -- tests/state/test_task_state.test.ts tests/workspace/test_workspace_view.test.ts`；`cd backend && uv run ruff check .`；`cd backend && uv run mypy app tests`；`cd frontend && npm run typecheck`；`cd frontend && npm run lint`；`git diff --check`
+- 浏览器验证：未执行真实浏览器 E2E；本轮只处理 US-005，完整真实浏览器路径和截图证据留给 US-007。
+- **未来迭代的学习：**
+  - `_ensure_run_deliverables()` 的返回值会直接进入 task/run `needs_input` 和 `needs_input` event payload，不能在这里放用户不应看到的诊断字段。
+  - 旧会话 payload 可能仍包含内部字段；前端展示前需要在标准化和 `formatNeedsInput()` 两层过滤，避免状态 notice 或历史数据泄漏字段名。
+  - 交付失败不能用 warning 消息卡片，否则标题会变成“配置提醒”；已知交付失败内容应走 error tone，显示“生成失败”。
 ---

--- a/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
@@ -12,7 +12,7 @@ Source: prd.json
 - 交付保护集中在 `backend/app/runner/core.py:524` 的 `_ensure_run_deliverables()`，当前 payload 暴露内部字段，需要收敛用户可见字段。
 - 前端 active 状态口径集中在 `frontend/app/task-state.ts:1349`，当前只把 `running` 视为 active，应补测试锁定。
 - needs-input notice 当前在 `frontend/app/workspace-view.ts:122` 作为 warning 输出，并在 `frontend/app/workspace-view.ts:1662` 显示为“配置提醒”，需要调整或过滤。
-- 文件-only submit 当前在 `frontend/hooks/use-task-workspace.ts:205` 允许发送，但 `frontend/hooks/use-task-workspace.ts:507` 使用通用默认 prompt，需要改成继续上一轮需求的 follow-up。
+- 文件-only submit 在 `frontend/hooks/use-task-workspace.ts` 中用 `buildFileOnlyFollowUpMessage()` 构造非空 follow-up；有历史用户意图时显式写“继续上一轮需求”，后端 `MessageRequest.message` 仍保持非空合同。
 
 ## 2026-05-24 23:14 - US-001
 - 实现了缺上传/缺正文时的普通 AI 澄清：runner 在启动 agent 前识别“总结/生成交付物但没有上传、内联正文或可复用上下文”的请求，直接写入 assistant 澄清并以 success final_answer 完成 run，不再产生 `needs_input` warning。
@@ -23,4 +23,16 @@ Source: prd.json
   - 缺上传澄清需要避开 `needs_input` 状态，否则前端会把 notice 渲染成 warning/“配置提醒”。
   - runner 的 `start_run()` 已先写入当前 user message，判断“是否有历史上下文”时要排除当前 `run_id` 的消息。
   - 交付保护测试若要验证 artifact 缺失/提升，应提供上传、内联正文或历史上下文，否则会先命中缺来源澄清。
+---
+
+## 2026-05-24 23:32 - US-002
+- 实现了文件-only follow-up：输入框为空但选中文件时，前端发送“继续上一轮需求”的非空消息，并带上上一轮用户意图和本轮文件名。
+- 补齐上传后发送失败的回归锁定：上传始终先于 message 发送，message 失败时刷新当前 task，且不清空已选文件状态。
+- 补齐后端上下文回归：文件-only follow-up 的下一轮上下文包含上一轮“总结内容并生成 Word”意图，上传资源 manifest 包含文件名但不包含上传正文。
+- 更改的文件：`frontend/hooks/use-task-workspace.ts`、`frontend/tests/workspace/test_task_workspace.test.ts`、`backend/tests/unit/runner/test_conversation_context.py`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd frontend && npm test -- tests/workspace/test_task_workspace.test.ts`；`cd backend && uv run pytest tests/unit/runner/test_conversation_context.py -q`；`cd frontend && npm run typecheck`；`cd frontend && npm run lint`；`cd backend && uv run ruff check .`；`cd backend && uv run mypy app tests`；`git diff --check`
+- **未来迭代的学习：**
+  - 前端文件-only 发送不能提交空 message，因为后端 `MessageRequest.message` 有 `min_length=1`；应在 hook 层生成清晰 follow-up。
+  - 会话连续性由 `ConversationContextBuilder` 回放上一轮消息，上传文件内容由 runner 的资源 manifest 和资源工具提供，不应写入普通 message。
+  - `uploadTaskFiles()` 成功但 `postTaskMessage()` 失败时要保留用户可见上传状态，catch 分支的 `refreshTask(requestTaskId)` 是必要兜底。
 ---

--- a/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
@@ -19,6 +19,7 @@ Source: prd.json
 - 交付成功判断以当前 run 的 `artifact_names` 后缀满足请求类型为准；请求类型已满足时不要再用 final answer 中的具体文件名做失败判定。
 - 交付失败的 `needs_input` payload 对用户可见时只保留 `message`/`action_label`；历史内部字段在 `frontend/app/task-state.ts` 的 needs-input 标准化和格式化中统一过滤。
 - 真实浏览器 E2E 若要点击“清空所有会话”，应使用隔离的 `MYAGENT_E2E_POSTGRES_DB` 和 `MYAGENT_E2E_TASK_ROOT`，避免删除开发库中的真实历史会话。
+- `runtime-contracts` 这类会直接用 `docker exec PostgreSQL psql` 播种的 E2E，后端 `MYAGENT_DATABASE_URL` 必须指向同一个 Docker Postgres 数据面；WSL 后端可用 `host.docker.internal:5432` 对齐。
 
 ## 2026-05-24 23:14 - US-001
 - 实现了缺上传/缺正文时的普通 AI 澄清：runner 在启动 agent 前识别“总结/生成交付物但没有上传、内联正文或可复用上下文”的请求，直接写入 assistant 澄清并以 success final_answer 完成 run，不再产生 `needs_input` warning。
@@ -101,4 +102,16 @@ Source: prd.json
   - 会改动文件-only follow-up 文案时必须同步 `GENERATED_FILE_ONLY_MESSAGE_PREFIXES` 和状态标准化单测，否则 UI 会退回展示 prompt 文本。
   - clear-all E2E 需要隔离数据库和任务根；否则“清空所有会话”会按真实产品路径删除当前后端返回的全部历史。
   - 对 provider 不相关的浏览器 E2E，可让缺上传澄清走真实后端短路，后续生成交付物路径用 Postgres-backed seed 保持测试可重复。
+---
+
+## 2026-05-25 10:23 - US-008
+- 同步了长期知识包 `asset/deepagents_platform_knowledge_pack.md`：记录缺上传/缺正文应作为普通 assistant 澄清、`needs_input` 是非运行状态、交付成功按当前 run 可下载 artifact 类型判定、交付失败后台保护保留但用户可见层隐藏内部字段。
+- 跑完完整质量门：后端全量 pytest/ruff/mypy、前端 typecheck/test/lint/build、`git diff --check` 和真实浏览器 `runtime-contracts`。
+- `runtime-contracts` 截图证据保存到 `tasks/missing-upload-clarification-delivery-warning-fix/screenshots/runtime-contracts-20260525102213/`，证据目录保持不提交。
+- 更改的文件：`asset/deepagents_platform_knowledge_pack.md`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd backend && uv run pytest && uv run ruff check . && uv run mypy app tests`；`cd frontend && npm run typecheck && npm test && npm run lint && npm run build`；`cd frontend && npm run e2e:runtime-contracts`；`git diff --check`
+- **未来迭代的学习：**
+  - `runtime-contracts` 同时通过公开 API 创建 task、又通过 Docker Postgres 直接播种 runs/messages/events；后端数据库 URL 和 `MYAGENT_E2E_POSTGRES_DB` 必须是同一数据面，否则会触发 runs 外键找不到 task。
+  - 在 WSL 后端连接 Docker Desktop 暴露的 Postgres 时，`host.docker.internal:5432` 比容器内网 IP 更稳定。
+  - 证据截图可写入需求目录 `screenshots/`；仓库 `.gitignore` 会保持这些时间戳证据不进入提交。
 ---

--- a/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
@@ -15,8 +15,10 @@ Source: prd.json
 - needs-input notice 当前在 `frontend/app/workspace-view.ts:122` 作为 warning 输出，并在 `frontend/app/workspace-view.ts:1662` 显示为“配置提醒”，需要调整或过滤。
 - 文件-only submit 在 `frontend/hooks/use-task-workspace.ts` 中用 `buildFileOnlyFollowUpMessage()` 构造非空 follow-up；有历史用户意图时显式写“继续上一轮需求”，后端 `MessageRequest.message` 仍保持非空合同。
 - 文件-only 用户消息展示由 `frontend/app/task-state.ts` 提取安全文件名元数据到 `ChatMessage.files`/`fileOnly`，`TaskConversation` 可隐藏生成式 follow-up 文案但保留原始 `content` 供复制和上下文使用。
+- `frontend/app/task-state.ts` 的文件-only 消息识别前缀必须与 `frontend/hooks/use-task-workspace.ts` 的 `buildFileOnlyFollowUpMessage()` 生成文案同步，否则浏览器会显示 follow-up prompt 而不是文件 chip。
 - 交付成功判断以当前 run 的 `artifact_names` 后缀满足请求类型为准；请求类型已满足时不要再用 final answer 中的具体文件名做失败判定。
 - 交付失败的 `needs_input` payload 对用户可见时只保留 `message`/`action_label`；历史内部字段在 `frontend/app/task-state.ts` 的 needs-input 标准化和格式化中统一过滤。
+- 真实浏览器 E2E 若要点击“清空所有会话”，应使用隔离的 `MYAGENT_E2E_POSTGRES_DB` 和 `MYAGENT_E2E_TASK_ROOT`，避免删除开发库中的真实历史会话。
 
 ## 2026-05-24 23:14 - US-001
 - 实现了缺上传/缺正文时的普通 AI 澄清：runner 在启动 agent 前识别“总结/生成交付物但没有上传、内联正文或可复用上下文”的请求，直接写入 assistant 澄清并以 success final_answer 完成 run，不再产生 `needs_input` warning。
@@ -87,4 +89,16 @@ Source: prd.json
   - 后端删除会话必须同时检查持久状态和 `runner.is_running(task_id)`，防止状态尚未刷新时误删 active run。
   - `needs_input` 是可继续、可删除、可清空的非运行终态；前端如需判断历史中是否有活跃任务，应统一走 `isTaskActive()`。
   - 清空历史的前端单测更适合锁定纯 helper 和 hook source boundary；真实浏览器“清空所有会话”路径由 US-007 覆盖。
+---
+
+## 2026-05-25 01:54 - US-007
+- 新增真实浏览器 E2E `frontend/e2e-playwright/test_missing_upload_clarification_delivery_warning.spec.mjs`，覆盖缺上传普通澄清、澄清后文件-only 上传继续上一轮需求、`.docx` 下载卡片、交付失败友好说明与内部字段隐藏、`needs_input` 可清空和 `running` 阻止清空。
+- 修复文件-only 展示识别口径：`frontend/app/task-state.ts` 现在识别 `buildFileOnlyFollowUpMessage()` 生成的“我已上传文件，请继续上一轮需求”前缀，避免浏览器路径显示默认 follow-up 文案而不显示文件 chip。
+- 截图证据保存到 `frontend/e2e-playwright/e2e-20260525015235/missing-upload-clarification-delivery-warning-fix/`，并按 `.gitignore` 保持不提交。
+- 更改的文件：`frontend/e2e-playwright/test_missing_upload_clarification_delivery_warning.spec.mjs`、`frontend/app/task-state.ts`、`frontend/tests/state/test_task_state.test.ts`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd frontend && npx playwright test e2e-playwright/test_missing_upload_clarification_delivery_warning.spec.mjs --reporter=line`；`cd frontend && npm test -- tests/state/test_task_state.test.ts`；`cd frontend && npm run typecheck`；`cd frontend && npm run lint`；`git diff --check`
+- **未来迭代的学习：**
+  - 会改动文件-only follow-up 文案时必须同步 `GENERATED_FILE_ONLY_MESSAGE_PREFIXES` 和状态标准化单测，否则 UI 会退回展示 prompt 文本。
+  - clear-all E2E 需要隔离数据库和任务根；否则“清空所有会话”会按真实产品路径删除当前后端返回的全部历史。
+  - 对 provider 不相关的浏览器 E2E，可让缺上传澄清走真实后端短路，后续生成交付物路径用 Postgres-backed seed 保持测试可重复。
 ---

--- a/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
+++ b/tasks/missing-upload-clarification-delivery-warning-fix/progress.txt
@@ -6,9 +6,21 @@ Source: prd.json
 
 ## Codebase Patterns
 
+- 缺上传/缺正文的普通澄清应在 `backend/app/runner/core.py` 的 `start_background()` 调 agent 前短路，写入 assistant message 和 success `final_answer`，不要生成用户可见 `needs_input` warning。
 - 后端删除会话只应阻止真实运行中任务：`backend/app/api/tasks.py:142` 检查 `state.status == "running"` 或 `runner.is_running(task_id)`。
 - 发送消息允许从 `needs_input` 继续：`backend/app/api/tasks.py:170` 的 `expected_statuses` 包含 `needs_input`。
 - 交付保护集中在 `backend/app/runner/core.py:524` 的 `_ensure_run_deliverables()`，当前 payload 暴露内部字段，需要收敛用户可见字段。
 - 前端 active 状态口径集中在 `frontend/app/task-state.ts:1349`，当前只把 `running` 视为 active，应补测试锁定。
 - needs-input notice 当前在 `frontend/app/workspace-view.ts:122` 作为 warning 输出，并在 `frontend/app/workspace-view.ts:1662` 显示为“配置提醒”，需要调整或过滤。
 - 文件-only submit 当前在 `frontend/hooks/use-task-workspace.ts:205` 允许发送，但 `frontend/hooks/use-task-workspace.ts:507` 使用通用默认 prompt，需要改成继续上一轮需求的 follow-up。
+
+## 2026-05-24 23:14 - US-001
+- 实现了缺上传/缺正文时的普通 AI 澄清：runner 在启动 agent 前识别“总结/生成交付物但没有上传、内联正文或可复用上下文”的请求，直接写入 assistant 澄清并以 success final_answer 完成 run，不再产生 `needs_input` warning。
+- 保留有来源内容时的交付保护：将相关 runner 单测改为携带内联材料，继续覆盖“有来源但缺 artifact”会进入交付保护。
+- 更改的文件：`backend/app/runner/core.py`、`backend/tests/unit/runner/test_core.py`、`tasks/missing-upload-clarification-delivery-warning-fix/prd.json`、`tasks/missing-upload-clarification-delivery-warning-fix/progress.txt`
+- 验证：`cd backend && uv run pytest tests/unit/runner/test_core.py tests/unit/api/test_tasks.py -q`；`cd backend && uv run ruff check .`；`cd backend && uv run mypy app tests`；`git diff --check`
+- **未来迭代的学习：**
+  - 缺上传澄清需要避开 `needs_input` 状态，否则前端会把 notice 渲染成 warning/“配置提醒”。
+  - runner 的 `start_run()` 已先写入当前 user message，判断“是否有历史上下文”时要排除当前 `run_id` 的消息。
+  - 交付保护测试若要验证 artifact 缺失/提升，应提供上传、内联正文或历史上下文，否则会先命中缺来源澄清。
+---


### PR DESCRIPTION
## Summary
- 将缺上传/缺内容场景改为普通 AI 澄清
- 支持文件-only 上传继续上一轮需求并渲染文件消息
- 按本轮可下载 artifact 类型判定交付成功，收敛交付失败用户可见字段
- 锁定 needs_input 非运行状态，并补齐真实浏览器 E2E 与知识包

## Validation
- backend pytest / ruff / mypy
- frontend typecheck / test / lint / build
- Playwright runtime contracts and missing-upload delivery warning E2E